### PR TITLE
This closes #215

### DIFF
--- a/oasp4j-templates/oasp4j-template-server/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/oasp4j-templates/oasp4j-template-server/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -3,7 +3,34 @@
     xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <id>oasp4j-template-server</id>
+
+  <requiredProperties>
+    <requiredProperty key="earProjectName">
+      <defaultValue>.</defaultValue>
+    </requiredProperty>
+  </requiredProperties>
+
   <fileSets>
+  	<!--
+  		This file set allow the archetype to include ear packaging or not in the generated project.
+  		It's is based on the pattern name substitution that uses maven to generate the packaging.
+  		In archetype-resources exists a folder named  __earProjectName__, and based on the value of
+  		earProjectName renames the folder to the final module name.
+  		The default value is . (dot), that implies that the __earProjectName__ folder is renamed to
+  		. (dot), and don't create the ear project.
+
+  		Additionally, when the artifact creates the ear project, the generated pom.xml add the ear
+  		module to the generated project. This is possible due to take advantadge of velocity template
+  		used by maven archetype plugin, so it's is very important not to modify the filtered attribute
+  		value (true), that implies the ability of consider the files matching the include pattern as
+  		velocity templates.
+  	 -->
+	<fileSet packaged="false" filtered="true" encoding="UTF-8">
+      <directory>__earProjectName__</directory>
+      <includes>
+        <include>**/*.*</include>
+      </includes>
+    </fileSet>
     <!--
     <fileSet encoding="UTF-8">
       <directory>.settings</directory>

--- a/oasp4j-templates/oasp4j-template-server/src/main/resources/archetype-resources/__earProjectName__/pom.xml
+++ b/oasp4j-templates/oasp4j-template-server/src/main/resources/archetype-resources/__earProjectName__/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>${groupId}</groupId>
+		<artifactId>${artifactId}</artifactId>
+		<version>${version}</version>
+	</parent>
+
+	<groupId>${groupId}</groupId>
+	<artifactId>${earProjectName}</artifactId>
+	<name>${earProjectName}</name>
+	<description>Enterprise application packaging.</description>
+	<packaging>ear</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>${groupId}</groupId>
+			<artifactId>${artifactId}-server</artifactId>
+			<version>${project.version}</version>
+			<type>war</type>
+		</dependency>
+	</dependencies>
+</project>

--- a/oasp4j-templates/oasp4j-template-server/src/main/templates/archetype-resources/pom.xml
+++ b/oasp4j-templates/oasp4j-template-server/src/main/templates/archetype-resources/pom.xml
@@ -18,6 +18,9 @@
 
   <modules>
     <module>${artifactId}-core</module>
+#if($earProjectName != '.')
+    <module>${earProjectName}</module>
+#end
     <module>${artifactId}-server</module>
   </modules>
 

--- a/oasp4j-templates/oasp4j-template-server/src/test/resources/projects/enterprise/archetype.properties
+++ b/oasp4j-templates/oasp4j-template-server/src/test/resources/projects/enterprise/archetype.properties
@@ -2,5 +2,5 @@
 package=it.pkg
 version=0.1-SNAPSHOT
 groupId=archetype.it
-artifactId=basic
-earProjectName=.
+artifactId=enterprise
+earProjectName=${artifactId}-ear

--- a/oasp4j-templates/oasp4j-template-server/src/test/resources/projects/enterprise/goal.txt
+++ b/oasp4j-templates/oasp4j-template-server/src/test/resources/projects/enterprise/goal.txt
@@ -1,0 +1,1 @@
+install


### PR DESCRIPTION
Finally I decided to create additional project to generate the ear
packaging, due to allow applications customize the ear package and use
all the power of enterprise applications (additional web applications,
ejb modules, customize the enterprise application descriptior, …).

In order to simplify the solution, I modified the actual archetype to
allow final user add ear packaging or not. To add this capability to
archetype, I take the velocity engine used by maven archetype generator
combined with a new archetype property named earProjectName (default
value is dot (.), and imply not to create ear project). If you would
like to create ear packaging, the suggestion is to set earProjectName
property a value equivalent to ${artifactId}-ear.

A sample using the new archetype:
- For only war packaging (argumens before archetype:generate identifies
oasp artifact):
mvn -DarchetypeVersion=1.1.0 -DarchetypeGroupId=io.oasp.java.templates
-DarchetypeArtifactId=oasp4j-template-server archetype:generate
-DgroupId=archetype.it -DartifactId=basic -Dversion=0.1-SNAPSHOT
-Dpackage=it.pkg
- For war and ear packaging (argumens before archetype:generate
identifies oasp artifact):
mvn -DarchetypeVersion=1.1.0 -DarchetypeGroupId=io.oasp.java.templates
-DarchetypeArtifactId=oasp4j-template-server archetype:generate
-DgroupId=archetype.it -DartifactId=enterprise -Dversion=0.1-SNAPSHOT
-Dpackage=it.pkg -DearProjectName=enterprise-ear

Based on the value of earProjectName, the pom’s generated project, add
the ear module or not.

I modified the archetype project unit testing, to generate ear packaging
and only war packaging.

Please tell me if this solution is all right for you or maybe we must
look for another solution.