### PR TITLE
Changed rest exception response format for validation errors.

### DIFF
--- a/oasp4j-bom/pom.xml
+++ b/oasp4j-bom/pom.xml
@@ -223,6 +223,20 @@
         <version>1.54</version>
       </dependency>
 
+      <!-- Dependencies for testing constraint validation excepcion -->
+      <dependency>
+        <groupId>javax.el</groupId>
+        <artifactId>javax.el-api</artifactId>
+        <version>2.2.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.web</groupId>
+        <artifactId>javax.el</artifactId>
+        <version>2.2.4</version>
+        <scope>test</scope>
+      </dependency>
+
       <!-- *** INTERNAL DEPENDENCIES *** -->
       <dependency>
         <groupId>io.oasp.java.modules</groupId>

--- a/oasp4j-modules/oasp4j-rest/pom.xml
+++ b/oasp4j-modules/oasp4j-rest/pom.xml
@@ -68,14 +68,10 @@
     <dependency>
        <groupId>javax.el</groupId>
        <artifactId>javax.el-api</artifactId>
-       <version>2.2.4</version>
-     <scope>test</scope>
     </dependency>
     <dependency>
        <groupId>org.glassfish.web</groupId>
        <artifactId>javax.el</artifactId>
-       <version>2.2.4</version>
-     <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/oasp4j-modules/oasp4j-rest/pom.xml
+++ b/oasp4j-modules/oasp4j-rest/pom.xml
@@ -60,6 +60,23 @@
       <artifactId>oasp4j-test</artifactId>
       <scope>test</scope>
     </dependency>
+     <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+       <groupId>javax.el</groupId>
+       <artifactId>javax.el-api</artifactId>
+       <version>2.2.4</version>
+     <scope>test</scope>
+    </dependency>
+    <dependency>
+       <groupId>org.glassfish.web</groupId>
+       <artifactId>javax.el</artifactId>
+       <version>2.2.4</version>
+     <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
We now list every validation error for each attribute individually, so it can be parsed on the client side.
Validation format example:
{
  "message": "validation message",
  "code": "validation code",
  "uuid":generated uuid,
  "errors" : {
     "fieldname1" : [
         "message1",
         "message2"
     ],
     "fieldname2" : [
         "message3"
     ]
  }
}
 
In addition, I have added a test for Constraints Validation Exceptions. I needed to add hibernate libraries to pom.xml (as test scope) because it was neccesary a provider for validation. I guess you didn´t do it because you didn´t want to add dependencies with hibernate to the rest module. If you consider it´s wrong, let me know.
