### PR TITLE
Prevent exception when setting query timeout via AbstractSearchCriteria.

### DIFF
--- a/oasp4j-modules/oasp4j-jpa/src/main/java/io/oasp/module/jpa/dataaccess/base/AbstractGenericDao.java
+++ b/oasp4j-modules/oasp4j-jpa/src/main/java/io/oasp/module/jpa/dataaccess/base/AbstractGenericDao.java
@@ -251,7 +251,7 @@ public abstract class AbstractGenericDao<ID, E extends PersistenceEntity<ID>> im
     }
     Long timeout = criteria.getSearchTimeout();
     if (timeout != null) {
-      query.setHint("javax.persistence.query.timeout", timeout);
+      query.setHint("javax.persistence.query.timeout", timeout.intValue());
     }
   }
 
@@ -273,7 +273,7 @@ public abstract class AbstractGenericDao<ID, E extends PersistenceEntity<ID>> im
     }
     Long timeout = criteria.getSearchTimeout();
     if (timeout != null) {
-      query.setHint("javax.persistence.query.timeout", timeout);
+      query.setHint("javax.persistence.query.timeout", timeout.intValue());
     }
   }
 


### PR DESCRIPTION
Convert AbstractSearchCriteria's searchTimeout to an int, as hibernate expects the query hint
"javax.persistence.query.timeout" to be of type Integer or String.

This fixes #234