### PR TITLE
#230 avoid redundant version numbers in POMs

### DIFF
--- a/oasp4j-templates/oasp4j-template-server/build.xml
+++ b/oasp4j-templates/oasp4j-template-server/build.xml
@@ -29,7 +29,7 @@
     -->
 
   	<!-- **** root project **** -->
-  	<copy file="${template.input}/pom.xml" todir="${sample.output}">
+  	<copy file="${filtered.input}/pom.xml" todir="${sample.output}">
       <filterchain>
         <tokenfilter>
           <linetokenizer/>

--- a/oasp4j-templates/oasp4j-template-server/pom.xml
+++ b/oasp4j-templates/oasp4j-template-server/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <template.input>${basedir}/src/main/templates/archetype-resources</template.input>
+    <filtered.input>${basedir}/target/archetype</filtered.input>
     <sample.package>io.oasp.gastronomy.restaurant</sample.package>
     <sample.package.path>io/oasp/gastronomy/restaurant</sample.package.path>
     <sample.input>../../oasp4j-samples</sample.input>
@@ -51,6 +52,12 @@
   </properties>
 
   <build>
+    <resources>
+      <resource>
+        <directory>${basedir}/src/main/resources/</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <outputDirectory>target/archetype</outputDirectory>
     <extensions>
       <extension>
@@ -61,6 +68,16 @@
     </extensions>
 
 		<plugins>
+      <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-resources-plugin</artifactId>
+               <configuration>
+                   <delimiters>
+                       <delimiter>^*^</delimiter>
+                   </delimiters>
+                   <useDefaultDelimiters>false</useDefaultDelimiters>
+               </configuration>
+           </plugin>
 			<plugin>
 				<artifactId>maven-archetype-plugin</artifactId>
 				<version>2.2</version>

--- a/oasp4j-templates/oasp4j-template-server/src/main/resources/pom.xml
+++ b/oasp4j-templates/oasp4j-template-server/src/main/resources/pom.xml
@@ -9,8 +9,8 @@
   <description>Application based on the Open Application Standard Platform for Java (OASP4J).</description>
 
   <properties>
-    <spring.boot.version>1.1.11.RELEASE</spring.boot.version>
-    <java.version>1.7</java.version>
+    <spring.boot.version>^spring.boot.version^</spring.boot.version>
+    <java.version>^java.version^</java.version>
     <oasp.port.range>81</oasp.port.range>
     <oasp.http.port>${oasp.port.range}81</oasp.http.port>
     <oasp.db.port>${oasp.port.range}43</oasp.db.port>


### PR DESCRIPTION
I've moved 
`oasp4j/oasp4j-templates/oasp4j-template-server/src/main/templates/archetype-resources/pom.xml`
to:
`oasp4j/oasp4j-templates/oasp4j-template-server/src/main/resources/pom.xml`

and then added filtering for resources on the `oasp4j/oasp4j-templates/oasp4j-template-server/pom.xml`

I've added the properties :

- `spring.boot.version`
- `java.version`

Have you identified more variables to change?