### PR TITLE
#250 Unnecessary extension of AbstractBeanMapperSupport

### DIFF
--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/general/logic/base/AbstractComponentFacade.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/general/logic/base/AbstractComponentFacade.java
@@ -1,0 +1,16 @@
+package io.oasp.gastronomy.restaurant.general.logic.base;
+
+/**
+ * Abstract base class for any management implementation class in this application.
+ */
+public abstract class AbstractComponentFacade {
+
+  /**
+   * The constructor.
+   */
+  public AbstractComponentFacade() {
+
+    super();
+  }
+
+}

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/OffermanagementImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/OffermanagementImpl.java
@@ -1,8 +1,8 @@
 package io.oasp.gastronomy.restaurant.offermanagement.logic.impl;
 
-import io.oasp.gastronomy.restaurant.general.common.base.AbstractBeanMapperSupport;
 import io.oasp.gastronomy.restaurant.general.logic.api.UseCase;
 import io.oasp.gastronomy.restaurant.general.logic.api.to.BinaryObjectEto;
+import io.oasp.gastronomy.restaurant.general.logic.base.AbstractComponentFacade;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.Offermanagement;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.DrinkEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.MealEto;
@@ -31,7 +31,7 @@ import javax.inject.Named;
  * @author loverbec
  */
 @Named
-public class OffermanagementImpl extends AbstractBeanMapperSupport implements Offermanagement {
+public class OffermanagementImpl extends AbstractComponentFacade implements Offermanagement {
 
   private UcFindOffer ucFindOffer;
 

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesmanagementImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesmanagementImpl.java
@@ -1,7 +1,7 @@
 package io.oasp.gastronomy.restaurant.salesmanagement.logic.impl;
 
-import io.oasp.gastronomy.restaurant.general.common.base.AbstractBeanMapperSupport;
 import io.oasp.gastronomy.restaurant.general.logic.api.UseCase;
+import io.oasp.gastronomy.restaurant.general.logic.base.AbstractComponentFacade;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferEto;
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.datatype.PaymentStatus;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.Salesmanagement;
@@ -34,7 +34,7 @@ import javax.inject.Named;
  * @author hohwille
  */
 @Named
-public class SalesmanagementImpl extends AbstractBeanMapperSupport implements Salesmanagement {
+public class SalesmanagementImpl extends AbstractComponentFacade implements Salesmanagement {
 
   private UcFindOrderPosition ucFindOrderPosition;
 

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/impl/StaffmanagementImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/impl/StaffmanagementImpl.java
@@ -1,7 +1,7 @@
 package io.oasp.gastronomy.restaurant.staffmanagement.logic.impl;
 
-import io.oasp.gastronomy.restaurant.general.common.base.AbstractBeanMapperSupport;
 import io.oasp.gastronomy.restaurant.general.logic.api.UseCase;
+import io.oasp.gastronomy.restaurant.general.logic.base.AbstractComponentFacade;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.Staffmanagement;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberEto;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.usecase.UcFindStaffMember;
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
  */
 @Named
 @Component
-public class StaffmanagementImpl extends AbstractBeanMapperSupport implements Staffmanagement {
+public class StaffmanagementImpl extends AbstractComponentFacade implements Staffmanagement {
 
   private UcFindStaffMember ucFindStaffMember;
 

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementImpl.java
@@ -1,7 +1,7 @@
 package io.oasp.gastronomy.restaurant.tablemanagement.logic.impl;
 
-import io.oasp.gastronomy.restaurant.general.common.base.AbstractBeanMapperSupport;
 import io.oasp.gastronomy.restaurant.general.logic.api.UseCase;
+import io.oasp.gastronomy.restaurant.general.logic.base.AbstractComponentFacade;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.Tablemanagement;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableEto;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableSearchCriteriaTo;
@@ -20,7 +20,7 @@ import javax.inject.Named;
  * @author etomety
  */
 @Named
-public class TablemanagementImpl extends AbstractBeanMapperSupport implements Tablemanagement {
+public class TablemanagementImpl extends AbstractComponentFacade implements Tablemanagement {
 
   private UcFindTable ucFindTable;
 


### PR DESCRIPTION
As we talk in issue #250, I have added a new class: AbstractComponentFacade that only extends from Object and it is extended by XXXmanagementImpl classes.