### PR TITLE
Add pagination support for offer, product and staffmember entities

### DIFF
--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/general/common/api/datatype/Money.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/general/common/api/datatype/Money.java
@@ -13,7 +13,7 @@ import net.sf.mmm.util.lang.api.AbstractSimpleDatatype;
  *
  * @author hohwille
  */
-public class Money extends AbstractSimpleDatatype<BigDecimal> {
+public class Money extends AbstractSimpleDatatype<BigDecimal> implements Comparable {
 
   /** A {@link Money} instance where the {@link #getValue() amount} is <code>0</code>. */
   public static final Money ZERO = new Money(BigDecimal.ZERO);
@@ -41,6 +41,15 @@ public class Money extends AbstractSimpleDatatype<BigDecimal> {
 
     super(value);
     Objects.requireNonNull(value, "value");
+  }
+
+  /**
+   *
+   * The constructor.
+   */
+  public Money() {
+
+    super();
   }
 
   /**
@@ -77,6 +86,16 @@ public class Money extends AbstractSimpleDatatype<BigDecimal> {
   public String toString() {
 
     return getValue().toPlainString() + " " + getCurrency();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int compareTo(Object o) {
+
+    Money other = (Money) o;
+    return getValue().compareTo(other.getValue());
   }
 
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/api/dao/OfferDao.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/api/dao/OfferDao.java
@@ -26,6 +26,7 @@ public interface OfferDao extends ApplicationDao<OfferEntity>, MasterDataDao<Off
    *
    * @return the {@link List} with all {@link OfferEntity}s that match the {@link OfferFilter offers filter criteria}.
    */
+  @Deprecated
   List<OfferEntity> findOffersFiltered(OfferFilter offerFilterBo, OfferSortBy sortBy);
 
   /**

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/api/dao/OfferDao.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/api/dao/OfferDao.java
@@ -3,7 +3,9 @@ package io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.dao;
 import io.oasp.gastronomy.restaurant.general.dataaccess.api.dao.ApplicationDao;
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.OfferEntity;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 import io.oasp.module.jpa.dataaccess.api.MasterDataDao;
 
 import java.util.List;
@@ -25,5 +27,13 @@ public interface OfferDao extends ApplicationDao<OfferEntity>, MasterDataDao<Off
    * @return the {@link List} with all {@link OfferEntity}s that match the {@link OfferFilter offers filter criteria}.
    */
   List<OfferEntity> findOffersFiltered(OfferFilter offerFilterBo, OfferSortBy sortBy);
+
+  /**
+   * Finds the {@link OfferEntity} objects matching the given {@link OfferSearchCriteriaTo}.
+   *
+   * @param criteria is the {@link OfferSearchCriteriaTo}.
+   * @return the {@link List} with the matching {@link OfferEntity} objects.
+   */
+  PaginatedListTo<OfferEntity> findOffers(OfferSearchCriteriaTo criteria);
 
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/api/dao/ProductDao.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/api/dao/ProductDao.java
@@ -3,7 +3,9 @@ package io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.dao;
 import io.oasp.gastronomy.restaurant.general.dataaccess.api.dao.ApplicationRevisionedDao;
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.ProductEntity;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 import io.oasp.module.jpa.dataaccess.api.MasterDataDao;
 
 import java.util.List;
@@ -20,6 +22,15 @@ public interface ProductDao extends ApplicationRevisionedDao<ProductEntity>, Mas
    * @param sortBy is the {@link ProductSortBy} criteria.
    * @return the {@link List} of filtered and sorted {@link ProductEntity products}.
    */
+  @Deprecated
   List<ProductEntity> findProductsFiltered(ProductFilter productFilter, ProductSortBy sortBy);
+
+  /**
+   * Finds the {@link ProductEntity} objects matching the given {@link ProductSearchCriteriaTo}.
+   *
+   * @param criteria is the {@link ProductSearchCriteriaTo}.
+   * @return the {@link List} with the matching {@link ProductEntity} objects.
+   */
+  PaginatedListTo<ProductEntity> findProducts(ProductSearchCriteriaTo criteria);
 
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/impl/dao/OfferDaoImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/impl/dao/OfferDaoImpl.java
@@ -3,13 +3,16 @@ package io.oasp.gastronomy.restaurant.offermanagement.dataaccess.impl.dao;
 import io.oasp.gastronomy.restaurant.general.common.api.datatype.Money;
 import io.oasp.gastronomy.restaurant.general.dataaccess.base.dao.ApplicationMasterDataDaoImpl;
 import io.oasp.gastronomy.restaurant.offermanagement.common.api.datatype.OfferSortByHitEntry;
+import io.oasp.gastronomy.restaurant.offermanagement.common.api.datatype.OfferState;
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.DrinkEntity;
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.MealEntity;
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.OfferEntity;
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.SideDishEntity;
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.dao.OfferDao;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +26,10 @@ import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+
+import com.mysema.query.alias.Alias;
+import com.mysema.query.jpa.impl.JPAQuery;
+import com.mysema.query.types.path.EntityPathBase;
 
 /**
  * Implementation of {@link OfferDao}.
@@ -40,19 +47,14 @@ public class OfferDaoImpl extends ApplicationMasterDataDaoImpl<OfferEntity> impl
     super();
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public Class<OfferEntity> getEntityClass() {
 
     return OfferEntity.class;
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
+  @Deprecated
   public List<OfferEntity> findOffersFiltered(OfferFilter offerFilterBo, OfferSortBy sortBy) {
 
     /*
@@ -167,5 +169,46 @@ public class OfferDaoImpl extends ApplicationMasterDataDaoImpl<OfferEntity> impl
     List<OfferEntity> result = typedQuery.getResultList();
 
     return result;
+  }
+
+  @Override
+  public PaginatedListTo<OfferEntity> findOffers(OfferSearchCriteriaTo criteria) {
+
+    OfferEntity offer = Alias.alias(OfferEntity.class);
+    EntityPathBase<OfferEntity> alias = Alias.$(offer);
+    JPAQuery query = new JPAQuery(getEntityManager()).from(alias);
+
+    Long number = criteria.getNumber();
+    if (number != null) {
+      query.where(Alias.$(offer.getNumber()).eq(number));
+    }
+    Long mealId = criteria.getMealId();
+    if (mealId != null) {
+      query.where(Alias.$(offer.getMealId()).eq(mealId));
+    }
+    Long drinkId = criteria.getDrinkId();
+    if (drinkId != null) {
+      query.where(Alias.$(offer.getDrinkId()).eq(drinkId));
+    }
+    Long sideDishId = criteria.getSideDishId();
+    if (sideDishId != null) {
+      query.where(Alias.$(offer.getSideDishId()).eq(sideDishId));
+    }
+    OfferState state = criteria.getState();
+    if (state != null) {
+      query.where(Alias.$(offer.getState()).eq(state));
+    }
+
+    Money minPrice = criteria.getMinPrice();
+    if (minPrice != null) {
+      query.where(Alias.$(offer.getPrice()).goe(minPrice));
+    }
+
+    Money maxPrice = criteria.getMaxPrice();
+    if (maxPrice != null) {
+      query.where(Alias.$(offer.getPrice()).loe(maxPrice));
+    }
+
+    return findPaginated(criteria, query, alias);
   }
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/impl/dao/ProductDaoImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/impl/dao/ProductDaoImpl.java
@@ -11,6 +11,8 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
 import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.jpa.common.api.to.PaginationResultTo;
+import io.oasp.module.jpa.common.api.to.PaginationTo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -175,7 +177,20 @@ public class ProductDaoImpl extends ApplicationMasterDataDaoImpl<ProductEntity> 
       query.where(Alias.$(product.getDescription()).eq(description));
     }
 
+    System.out.println("criteria: " + criteria.toStrink());
+
     // include filter for entity type
+
+    if (!(criteria.isFetchDrinks() || criteria.isFetchMeals() || criteria.isFetchSideDishes())) {
+      // no product type was selected, return empty result
+      PaginationTo pagination = criteria.getPagination();
+
+      PaginationResultTo paginationResult = new PaginationResultTo(pagination, 0L);
+      List<ProductEntity> paginatedList = new ArrayList<>();
+
+      return new PaginatedListTo<>(paginatedList, paginationResult);
+    }
+
     BooleanBuilder builder = new BooleanBuilder();
     if (criteria.isFetchSideDishes()) {
       builder.or(Alias.$(product).instanceOf(SideDishEntity.class));

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/impl/dao/ProductDaoImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/impl/dao/ProductDaoImpl.java
@@ -8,7 +8,9 @@ import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.ProductEntit
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.SideDishEntity;
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.dao.ProductDao;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +22,11 @@ import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
+
+import com.mysema.query.BooleanBuilder;
+import com.mysema.query.alias.Alias;
+import com.mysema.query.jpa.impl.JPAQuery;
+import com.mysema.query.types.path.EntityPathBase;
 
 /**
  * Implementation of {@link ProductDao}.
@@ -50,6 +57,7 @@ public class ProductDaoImpl extends ApplicationMasterDataDaoImpl<ProductEntity> 
    * {@inheritDoc}
    */
   @Override
+  @Deprecated
   public List<ProductEntity> findProductsFiltered(ProductFilter productFilterBo, ProductSortBy sortBy) {
 
     /*
@@ -148,5 +156,38 @@ public class ProductDaoImpl extends ApplicationMasterDataDaoImpl<ProductEntity> 
     List<ProductEntity> result = getEntityManager().createQuery(criteriaQuery).getResultList();
 
     return result;
+  }
+
+  @Override
+  public PaginatedListTo<ProductEntity> findProducts(ProductSearchCriteriaTo criteria) {
+
+    ProductEntity product = Alias.alias(ProductEntity.class);
+    EntityPathBase<ProductEntity> alias = Alias.$(product);
+    JPAQuery query = new JPAQuery(getEntityManager()).from(alias);
+
+    String name = criteria.getName();
+    if (name != null) {
+      query.where(Alias.$(product.getName()).eq(name));
+    }
+
+    String description = criteria.getDescription();
+    if (description != null) {
+      query.where(Alias.$(product.getDescription()).eq(description));
+    }
+
+    // include filter for entity type
+    BooleanBuilder builder = new BooleanBuilder();
+    if (criteria.isFetchSideDishes()) {
+      builder.or(Alias.$(product).instanceOf(SideDishEntity.class));
+    }
+    if (criteria.isFetchMeals()) {
+      builder.or(Alias.$(product).instanceOf(MealEntity.class));
+    }
+    if (criteria.isFetchDrinks()) {
+      builder.or(Alias.$(product).instanceOf(DrinkEntity.class));
+    }
+    query.where(builder);
+
+    return findPaginated(criteria, query, alias);
   }
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/OfferSearchCriteriaTo.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/OfferSearchCriteriaTo.java
@@ -1,0 +1,152 @@
+package io.oasp.gastronomy.restaurant.offermanagement.logic.api.to;
+
+import io.oasp.gastronomy.restaurant.general.common.api.datatype.Money;
+import io.oasp.gastronomy.restaurant.offermanagement.common.api.datatype.OfferState;
+import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+
+/**
+ * This is the {@link SearchCriteriaTo search criteria} {@link net.sf.mmm.util.transferobject.api.TransferObject TO}
+ * used to find {@link io.oasp.gastronomy.restaurant.salesmanagement.common.api.Order}s.
+ *
+ * @author hohwille
+ */
+public class OfferSearchCriteriaTo extends SearchCriteriaTo {
+
+  /** UID for serialization. */
+  private static final long serialVersionUID = 1L;
+
+  private Long number;
+
+  private Money minPrice;
+
+  private Money maxPrice;
+
+  private Long mealId;
+
+  private Long drinkId;
+
+  private Long sideDishId;
+
+  private OfferState state;
+
+  /**
+   * The constructor.
+   */
+  public OfferSearchCriteriaTo() {
+
+    super();
+  }
+
+  /**
+   * @return number
+   */
+  public Long getNumber() {
+
+    return this.number;
+  }
+
+  /**
+   * @param number the number to set
+   */
+  public void setNumber(Long number) {
+
+    this.number = number;
+  }
+
+  /**
+   * @return minPrice
+   */
+  public Money getMinPrice() {
+
+    return this.minPrice;
+  }
+
+  /**
+   * @param minPrice the minPrice to set
+   */
+  public void setMinPrice(Money minPrice) {
+
+    this.minPrice = minPrice;
+  }
+
+  /**
+   * @return maxPrice
+   */
+  public Money getMaxPrice() {
+
+    return this.maxPrice;
+  }
+
+  /**
+   * @param maxPrice the maxPrice to set
+   */
+  public void setMaxPrice(Money maxPrice) {
+
+    this.maxPrice = maxPrice;
+  }
+
+  /**
+   * @return mealId
+   */
+  public Long getMealId() {
+
+    return this.mealId;
+  }
+
+  /**
+   * @param mealId the mealId to set
+   */
+  public void setMealId(Long mealId) {
+
+    this.mealId = mealId;
+  }
+
+  /**
+   * @return drinkId
+   */
+  public Long getDrinkId() {
+
+    return this.drinkId;
+  }
+
+  /**
+   * @param drinkId the drinkId to set
+   */
+  public void setDrinkId(Long drinkId) {
+
+    this.drinkId = drinkId;
+  }
+
+  /**
+   * @return sideDishId
+   */
+  public Long getSideDishId() {
+
+    return this.sideDishId;
+  }
+
+  /**
+   * @param sideDishId the sideDishId to set
+   */
+  public void setSideDishId(Long sideDishId) {
+
+    this.sideDishId = sideDishId;
+  }
+
+  /**
+   * @return state
+   */
+  public OfferState getState() {
+
+    return this.state;
+  }
+
+  /**
+   * @param state the state to set
+   */
+  public void setState(OfferState state) {
+
+    this.state = state;
+  }
+
+}

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/ProductSearchCriteriaTo.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/ProductSearchCriteriaTo.java
@@ -6,6 +6,9 @@ import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
  * This is the {@link SearchCriteriaTo search criteria} {@link net.sf.mmm.util.transferobject.api.TransferObject TO}
  * used to find {@link io.oasp.gastronomy.restaurant.salesmanagement.common.api.Product}s.
  *
+ * If no boolean is set to true, no {@link io.oasp.gastronomy.restaurant.salesmanagement.common.api.Product}s will be
+ * found.
+ *
  * @author lgoerlac
  */
 public class ProductSearchCriteriaTo extends SearchCriteriaTo {
@@ -31,8 +34,9 @@ public class ProductSearchCriteriaTo extends SearchCriteriaTo {
     super();
 
     this.fetchDrinks = true;
-    this.fetchMeals = false;
+    this.fetchMeals = true;
     this.fetchSideDishes = true;
+
   }
 
   /**
@@ -113,6 +117,13 @@ public class ProductSearchCriteriaTo extends SearchCriteriaTo {
   public void setDescription(String description) {
 
     this.description = description;
+  }
+
+  public String toStrink() {
+
+    return "ProductSearchCriteriaTo [fetchDrinks=" + this.fetchDrinks + ", fetchMeals=" + this.fetchMeals
+        + ", fetchSideDishes=" + this.fetchSideDishes + ", name=" + this.name + ", description=" + this.description
+        + "]";
   }
 
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/ProductSearchCriteriaTo.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/ProductSearchCriteriaTo.java
@@ -1,0 +1,118 @@
+package io.oasp.gastronomy.restaurant.offermanagement.logic.api.to;
+
+import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+
+/**
+ * This is the {@link SearchCriteriaTo search criteria} {@link net.sf.mmm.util.transferobject.api.TransferObject TO}
+ * used to find {@link io.oasp.gastronomy.restaurant.salesmanagement.common.api.Product}s.
+ *
+ * @author lgoerlac
+ */
+public class ProductSearchCriteriaTo extends SearchCriteriaTo {
+
+  /** UID for serialization. */
+  private static final long serialVersionUID = 1L;
+
+  private boolean fetchDrinks;
+
+  private boolean fetchMeals;
+
+  private boolean fetchSideDishes;
+
+  private String name;
+
+  private String description;
+
+  /**
+   * The constructor.
+   */
+  public ProductSearchCriteriaTo() {
+
+    super();
+
+    this.fetchDrinks = true;
+    this.fetchMeals = false;
+    this.fetchSideDishes = true;
+  }
+
+  /**
+   * @return fetchDrinks
+   */
+  public boolean isFetchDrinks() {
+
+    return this.fetchDrinks;
+  }
+
+  /**
+   * @param fetchDrinks the fetchDrinks to set
+   */
+  public void setFetchDrinks(boolean fetchDrinks) {
+
+    this.fetchDrinks = fetchDrinks;
+  }
+
+  /**
+   * @return fetchMeals
+   */
+  public boolean isFetchMeals() {
+
+    return this.fetchMeals;
+  }
+
+  /**
+   * @param fetchMeals the fetchMeals to set
+   */
+  public void setFetchMeals(boolean fetchMeals) {
+
+    this.fetchMeals = fetchMeals;
+  }
+
+  /**
+   * @return fetchSideDishes
+   */
+  public boolean isFetchSideDishes() {
+
+    return this.fetchSideDishes;
+  }
+
+  /**
+   * @param fetchSideDishes the fetchSideDishes to set
+   */
+  public void setFetchSideDishes(boolean fetchSideDishes) {
+
+    this.fetchSideDishes = fetchSideDishes;
+  }
+
+  /**
+   * @return name
+   */
+  public String getName() {
+
+    return this.name;
+  }
+
+  /**
+   * @param name the name to set
+   */
+  public void setName(String name) {
+
+    this.name = name;
+  }
+
+  /**
+   * @return description
+   */
+  public String getDescription() {
+
+    return this.description;
+  }
+
+  /**
+   * @param description the description to set
+   */
+  public void setDescription(String description) {
+
+    this.description = description;
+  }
+
+}

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/usecase/UcFindOffer.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/usecase/UcFindOffer.java
@@ -38,6 +38,7 @@ public interface UcFindOffer {
   /**
    * @return the {@link List} with all available {@link OfferEto}s.
    */
+  @Deprecated
   List<OfferEto> findAllOffers();
 
   /**
@@ -55,6 +56,7 @@ public interface UcFindOffer {
    *
    * @return the {@link List} with all {@link OfferEto}s that match the {@link OfferFilter} criteria.
    */
+  @Deprecated
   List<OfferEto> findOffersFiltered(OfferFilter offerFilterBo, OfferSortBy sortBy);
 
   /**

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/usecase/UcFindOffer.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/usecase/UcFindOffer.java
@@ -3,8 +3,10 @@ package io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferCto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductEto;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.util.List;
 
@@ -54,5 +56,13 @@ public interface UcFindOffer {
    * @return the {@link List} with all {@link OfferEto}s that match the {@link OfferFilter} criteria.
    */
   List<OfferEto> findOffersFiltered(OfferFilter offerFilterBo, OfferSortBy sortBy);
+
+  /**
+   * Returns a list of offers matching the search criteria.
+   *
+   * @param criteria the {@link OfferSearchCriteriaTo}.
+   * @return the {@link List} of matching {@link OfferEto}s.
+   */
+  PaginatedListTo<OfferEto> findOfferEtos(OfferSearchCriteriaTo criteria);
 
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/usecase/UcFindProduct.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/usecase/UcFindProduct.java
@@ -5,8 +5,10 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.DrinkEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.MealEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.SideDishEto;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.sql.Blob;
 import java.util.List;
@@ -70,22 +72,26 @@ public interface UcFindProduct {
   /**
    * @return the {@link List} with all {@link io.oasp.gastronomy.restaurant.offermanagement.common.api.Product}s.
    */
+  @Deprecated
   List<ProductEto> findAllProducts();
 
   /**
    * @return the {@link List} with all {@link io.oasp.gastronomy.restaurant.offermanagement.common.api.Meal meals}.
    */
+  @Deprecated
   List<MealEto> findAllMeals();
 
   /**
    * @return the {@link List} with all {@link io.oasp.gastronomy.restaurant.offermanagement.common.api.Drink drinks}.
    */
+  @Deprecated
   List<DrinkEto> findAllDrinks();
 
   /**
    * @return the {@link List} with all {@link io.oasp.gastronomy.restaurant.offermanagement.common.api.SideDish side
    *         dishes}.
    */
+  @Deprecated
   List<SideDishEto> findAllSideDishes();
 
   /**
@@ -95,7 +101,16 @@ public interface UcFindProduct {
    * @param sortBy sorting specification
    * @return a {@link List} of filtered products
    */
+  @Deprecated
   List<ProductEto> findProductsFiltered(ProductFilter productFilterBo, ProductSortBy sortBy);
+
+  /**
+   * Returns a list of products matching the search criteria.
+   *
+   * @param criteria the {@link ProductSearchCriteriaTo}.
+   * @return the {@link List} of matching {@link ProductEto}s.
+   */
+  PaginatedListTo<ProductEto> findProductEtos(ProductSearchCriteriaTo criteria);
 
   /**
    * @param productId the ID of the {@link ProductEto} to get the picture

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/OffermanagementImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/OffermanagementImpl.java
@@ -9,6 +9,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.MealEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferCto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
@@ -18,6 +19,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcFindOff
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcFindProduct;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcManageOffer;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcManageProduct;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.sql.Blob;
 import java.util.List;
@@ -307,6 +309,15 @@ public class OffermanagementImpl extends AbstractComponentFacade implements Offe
   public ProductEto findProductByRevision(Long id, Number revision) {
 
     return this.ucFindProduct.findProductByRevision(id, revision);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PaginatedListTo<OfferEto> findOfferEtos(OfferSearchCriteriaTo criteria) {
+
+    return this.ucFindOffer.findOfferEtos(criteria);
   }
 
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/OffermanagementImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/OffermanagementImpl.java
@@ -13,6 +13,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSearchCri
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.SideDishEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcFindOffer;
@@ -121,6 +122,7 @@ public class OffermanagementImpl extends AbstractComponentFacade implements Offe
    * {@inheritDoc}
    */
   @Override
+  @Deprecated
   public List<OfferEto> findAllOffers() {
 
     return this.ucFindOffer.findAllOffers();
@@ -130,6 +132,7 @@ public class OffermanagementImpl extends AbstractComponentFacade implements Offe
    * {@inheritDoc}
    */
   @Override
+  @Deprecated
   public List<ProductEto> findAllProducts() {
 
     return this.ucFindProduct.findAllProducts();
@@ -139,6 +142,7 @@ public class OffermanagementImpl extends AbstractComponentFacade implements Offe
    * {@inheritDoc}
    */
   @Override
+  @Deprecated
   public List<MealEto> findAllMeals() {
 
     return this.ucFindProduct.findAllMeals();
@@ -148,6 +152,7 @@ public class OffermanagementImpl extends AbstractComponentFacade implements Offe
    * {@inheritDoc}
    */
   @Override
+  @Deprecated
   public List<DrinkEto> findAllDrinks() {
 
     return this.ucFindProduct.findAllDrinks();
@@ -177,6 +182,7 @@ public class OffermanagementImpl extends AbstractComponentFacade implements Offe
    * {@inheritDoc}
    */
   @Override
+  @Deprecated
   public List<SideDishEto> findAllSideDishes() {
 
     return this.ucFindProduct.findAllSideDishes();
@@ -251,6 +257,7 @@ public class OffermanagementImpl extends AbstractComponentFacade implements Offe
    * {@inheritDoc}
    */
   @Override
+  @Deprecated
   public List<OfferEto> findOffersFiltered(OfferFilter offerFilterBo, OfferSortBy sortBy) {
 
     return this.ucFindOffer.findOffersFiltered(offerFilterBo, sortBy);
@@ -260,6 +267,7 @@ public class OffermanagementImpl extends AbstractComponentFacade implements Offe
    * {@inheritDoc}
    */
   @Override
+  @Deprecated
   public List<ProductEto> findProductsFiltered(ProductFilter productFilterBo, ProductSortBy sortBy) {
 
     return this.ucFindProduct.findProductsFiltered(productFilterBo, sortBy);
@@ -318,6 +326,15 @@ public class OffermanagementImpl extends AbstractComponentFacade implements Offe
   public PaginatedListTo<OfferEto> findOfferEtos(OfferSearchCriteriaTo criteria) {
 
     return this.ucFindOffer.findOfferEtos(criteria);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PaginatedListTo<ProductEto> findProductEtos(ProductSearchCriteriaTo criteria) {
+
+    return this.ucFindProduct.findProductEtos(criteria);
   }
 
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/usecase/UcFindOfferImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/usecase/UcFindOfferImpl.java
@@ -10,11 +10,13 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.MealEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferCto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.SideDishEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcFindOffer;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.base.usecase.AbstractOfferUc;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -200,4 +202,15 @@ public class UcFindOfferImpl extends AbstractOfferUc implements UcFindOffer {
     return offerBos;
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @RolesAllowed(PermissionConstants.FIND_OFFER)
+  public PaginatedListTo<OfferEto> findOfferEtos(OfferSearchCriteriaTo criteria) {
+
+    criteria.limitMaximumPageSize(MAXIMUM_HIT_LIMIT);
+    PaginatedListTo<OfferEntity> offers = getOfferDao().findOffers(criteria);
+    return mapPaginatedEntityList(offers, OfferEto.class);
+  }
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/usecase/UcFindProductImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/usecase/UcFindProductImpl.java
@@ -11,10 +11,12 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.DrinkEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.MealEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.SideDishEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcFindProduct;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.base.usecase.AbstractProductUc;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.sql.Blob;
 import java.util.List;
@@ -149,6 +151,7 @@ public class UcFindProductImpl extends AbstractProductUc implements UcFindProduc
    */
   @Override
   @RolesAllowed(PermissionConstants.FIND_PRODUCT)
+  @Deprecated
   public List<ProductEto> findAllProducts() {
 
     LOG.debug("Get all products from database.");
@@ -160,6 +163,7 @@ public class UcFindProductImpl extends AbstractProductUc implements UcFindProduc
    */
   @Override
   @RolesAllowed(PermissionConstants.FIND_PRODUCT)
+  @Deprecated
   public List<MealEto> findAllMeals() {
 
     LOG.debug("Get all meals with from database.");
@@ -171,6 +175,7 @@ public class UcFindProductImpl extends AbstractProductUc implements UcFindProduc
    */
   @Override
   @RolesAllowed(PermissionConstants.FIND_PRODUCT)
+  @Deprecated
   public List<DrinkEto> findAllDrinks() {
 
     LOG.debug("Get all drinks with from database.");
@@ -182,6 +187,7 @@ public class UcFindProductImpl extends AbstractProductUc implements UcFindProduc
    */
   @Override
   @RolesAllowed(PermissionConstants.FIND_PRODUCT)
+  @Deprecated
   public List<SideDishEto> findAllSideDishes() {
 
     LOG.debug("Get all sidedishes with from database.");
@@ -193,6 +199,7 @@ public class UcFindProductImpl extends AbstractProductUc implements UcFindProduc
    */
   @Override
   @RolesAllowed(PermissionConstants.FIND_OFFER)
+  @Deprecated
   public List<ProductEto> findProductsFiltered(ProductFilter productFilterBo, ProductSortBy sortBy) {
 
     LOG.debug("Fetch filtered offers.");
@@ -233,5 +240,14 @@ public class UcFindProductImpl extends AbstractProductUc implements UcFindProduc
     } else {
       return getBeanMapper().map(product, ProductEto.class);
     }
+  }
+
+  @Override
+  @RolesAllowed(PermissionConstants.FIND_PRODUCT)
+  public PaginatedListTo<ProductEto> findProductEtos(ProductSearchCriteriaTo criteria) {
+
+    criteria.limitMaximumPageSize(MAXIMUM_HIT_LIMIT);
+    PaginatedListTo<ProductEntity> products = getProductDao().findProducts(criteria);
+    return mapPaginatedEntityList(products, ProductEto.class);
   }
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/service/impl/rest/OffermanagementRestServiceImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/service/impl/rest/OffermanagementRestServiceImpl.java
@@ -10,6 +10,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSearchCri
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.SideDishEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcFindOffer;
@@ -134,6 +135,7 @@ public class OffermanagementRestServiceImpl {
    */
   @GET
   @Path("/product/")
+  @Deprecated
   public List<ProductEto> getAllProducts() {
 
     return this.offerManagement.findAllProducts();
@@ -155,10 +157,13 @@ public class OffermanagementRestServiceImpl {
   /**
    * Delegates to {@link UcFindProduct#findAllMeals}.
    *
+   * @deprecated use {@link OffermanagementRestServiceImpl#findProductEtosByPost(ProductSearchCriteriaTo)} with
+   *             fetchMeals=true
    * @return all {@link MealEto}s as list
    */
   @GET
   @Path("/product/meal/")
+  @Deprecated
   public List<MealEto> getAllMeals() {
 
     return this.offerManagement.findAllMeals();
@@ -167,10 +172,13 @@ public class OffermanagementRestServiceImpl {
   /**
    * Delegates to {@link UcFindProduct#findAllDrinks}.
    *
+   * @deprecated use {@link OffermanagementRestServiceImpl#findProductEtosByPost(ProductSearchCriteriaTo)} with
+   *             fetchDrinks=true
    * @return all {@link DrinkEto}s as list
    */
   @GET
   @Path("/product/drink/")
+  @Deprecated
   public List<DrinkEto> getAllDrinks() {
 
     return this.offerManagement.findAllDrinks();
@@ -179,10 +187,13 @@ public class OffermanagementRestServiceImpl {
   /**
    * Delegates to {@link UcFindProduct#findAllSideDishes}.
    *
+   * @deprecated use {@link OffermanagementRestServiceImpl#findProductEtosByPost(ProductSearchCriteriaTo)} with
+   *             fetchSideDishes=true
    * @return all {@link SideDishEto}s as list
    */
   @GET
   @Path("/product/side/")
+  @Deprecated
   public List<SideDishEto> getAllSideDishes() {
 
     return this.offerManagement.findAllSideDishes();
@@ -296,6 +307,7 @@ public class OffermanagementRestServiceImpl {
    */
   @GET
   @Path("/product/sortby/{sortBy}")
+  @Deprecated
   public List<ProductEto> getFilteredProducts(ProductFilter productFilter, @PathParam("sortBy") ProductSortBy sortBy) {
 
     return this.offerManagement.findProductsFiltered(productFilter, sortBy);
@@ -354,4 +366,18 @@ public class OffermanagementRestServiceImpl {
 
     return this.offerManagement.findOfferEtos(searchCriteriaTo);
   }
+
+  /**
+   * Delegates to {@link UcFindProduct#findProductEtos}.
+   *
+   * @param searchCriteriaTo the pagination and search criteria to be used for finding products.
+   * @return the {@link PaginatedListTo list} of matching {@link ProductEto}s.
+   */
+  @Path("/product/search")
+  @POST
+  public PaginatedListTo<ProductEto> findProductEtosByPost(ProductSearchCriteriaTo searchCriteriaTo) {
+
+    return this.offerManagement.findProductEtos(searchCriteriaTo);
+  }
+
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/service/impl/rest/OffermanagementRestServiceImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/service/impl/rest/OffermanagementRestServiceImpl.java
@@ -6,6 +6,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.DrinkEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.MealEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferFilter;
+import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
@@ -15,6 +16,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcFindOff
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcFindProduct;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcManageOffer;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.usecase.UcManageProduct;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -119,6 +121,7 @@ public class OffermanagementRestServiceImpl {
    */
   @GET
   @Path("/offer/")
+  @Deprecated
   public List<OfferEto> getAllOffers() {
 
     return this.offerManagement.findAllOffers();
@@ -278,6 +281,7 @@ public class OffermanagementRestServiceImpl {
    */
   @GET
   @Path("/sortby/{sortBy}")
+  @Deprecated
   public List<OfferEto> getFilteredOffers(OfferFilter offerFilter, @PathParam("sortBy") OfferSortBy sortBy) {
 
     return this.offerManagement.findOffersFiltered(offerFilter, sortBy);
@@ -336,5 +340,18 @@ public class OffermanagementRestServiceImpl {
   public void deleteProductPicture(long productId) {
 
     this.offerManagement.deleteProductPicture(productId);
+  }
+
+  /**
+   * Delegates to {@link UcFindOffer#findOfferEtos}.
+   *
+   * @param searchCriteriaTo the pagination and search criteria to be used for finding offers.
+   * @return the {@link PaginatedListTo list} of matching {@link OfferEto}s.
+   */
+  @Path("/offer/search")
+  @POST
+  public PaginatedListTo<OfferEto> findOfferEtosByPost(OfferSearchCriteriaTo searchCriteriaTo) {
+
+    return this.offerManagement.findOfferEtos(searchCriteriaTo);
   }
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/dataaccess/api/dao/StaffMemberDao.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/dataaccess/api/dao/StaffMemberDao.java
@@ -2,6 +2,8 @@ package io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.api.dao;
 
 import io.oasp.gastronomy.restaurant.general.dataaccess.api.dao.ApplicationDao;
 import io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.api.StaffMemberEntity;
+import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 import io.oasp.module.jpa.dataaccess.api.MasterDataDao;
 
 /**
@@ -18,5 +20,13 @@ public interface StaffMemberDao extends ApplicationDao<StaffMemberEntity>, Maste
    * @return Staffmember
    */
   StaffMemberEntity findByLogin(String login);
+
+  /**
+   * Finds the {@link StaffMemberEntity} objects matching the given {@link StaffMemberSearchCriteriaTo}-
+   *
+   * @param criteria is the {@link StaffMemberSearchCriteriaTo}.
+   * @return the {@link PaginatedListTo} with the matching {@link StaffMemberEntity} objects.
+   */
+  PaginatedListTo<StaffMemberEntity> findStaffMembers(StaffMemberSearchCriteriaTo criteria);
 
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/dataaccess/impl/dao/StaffMemberDaoImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/dataaccess/impl/dao/StaffMemberDaoImpl.java
@@ -1,12 +1,19 @@
 package io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.impl.dao;
 
 import io.oasp.gastronomy.restaurant.general.common.api.constants.NamedQueries;
+import io.oasp.gastronomy.restaurant.general.common.api.datatype.Role;
 import io.oasp.gastronomy.restaurant.general.dataaccess.base.dao.ApplicationMasterDataDaoImpl;
 import io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.api.StaffMemberEntity;
 import io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.api.dao.StaffMemberDao;
+import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import javax.inject.Named;
 import javax.persistence.TypedQuery;
+
+import com.mysema.query.alias.Alias;
+import com.mysema.query.jpa.impl.JPAQuery;
+import com.mysema.query.types.path.EntityPathBase;
 
 /**
  * Implementation of {@link StaffMemberDao}.
@@ -43,5 +50,35 @@ public class StaffMemberDaoImpl extends ApplicationMasterDataDaoImpl<StaffMember
         getEntityManager().createNamedQuery(NamedQueries.GET_STAFF_MEMBER_BY_LOGIN, StaffMemberEntity.class);
     query.setParameter("login", login);
     return query.getSingleResult();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PaginatedListTo<StaffMemberEntity> findStaffMembers(StaffMemberSearchCriteriaTo criteria) {
+
+    StaffMemberEntity staffMember = Alias.alias(StaffMemberEntity.class);
+    EntityPathBase<StaffMemberEntity> alias = Alias.$(staffMember);
+    JPAQuery query = new JPAQuery(getEntityManager()).from(alias);
+
+    String firstName = criteria.getFirstName();
+    if (firstName != null) {
+      query.where(Alias.$(staffMember.getFirstName()).eq(firstName));
+    }
+    String lastName = criteria.getLastName();
+    if (lastName != null) {
+      query.where(Alias.$(staffMember.getLastName()).eq(lastName));
+    }
+    String name = criteria.getName();
+    if (name != null) {
+      query.where(Alias.$(staffMember.getName()).eq(name));
+    }
+    Role role = criteria.getRole();
+    if (role != null) {
+      query.where(Alias.$(staffMember.getRole()).eq(role));
+    }
+
+    return findPaginated(criteria, query, alias);
   }
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/api/to/StaffMemberSearchCriteriaTo.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/api/to/StaffMemberSearchCriteriaTo.java
@@ -1,0 +1,97 @@
+package io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to;
+
+import io.oasp.gastronomy.restaurant.general.common.api.datatype.Role;
+import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+
+/**
+ * This is the {@link SearchCriteriaTo search criteria} {@link net.sf.mmm.util.transferobject.api.TransferObject TO}
+ * used to find {@link io.oasp.gastronomy.restaurant.staffmanagement.common.api.StaffMember}s.
+ *
+ * @author hohwille
+ */
+public class StaffMemberSearchCriteriaTo extends SearchCriteriaTo {
+
+  /** UID for serialization. */
+  private static final long serialVersionUID = 1L;
+
+  private String name;
+
+  private String firstName;
+
+  private String lastName;
+
+  private Role role;
+
+  /**
+   * The constructor.
+   */
+  public StaffMemberSearchCriteriaTo() {
+
+    super();
+  }
+
+  /**
+   * @return name
+   */
+  public String getName() {
+
+    return this.name;
+  }
+
+  /**
+   * @param name the name to set
+   */
+  public void setName(String name) {
+
+    this.name = name;
+  }
+
+  /**
+   * @return firstName
+   */
+  public String getFirstName() {
+
+    return this.firstName;
+  }
+
+  /**
+   * @param firstName the firstName to set
+   */
+  public void setFirstName(String firstName) {
+
+    this.firstName = firstName;
+  }
+
+  /**
+   * @return lastName
+   */
+  public String getLastName() {
+
+    return this.lastName;
+  }
+
+  /**
+   * @param lastName the lastName to set
+   */
+  public void setLastName(String lastName) {
+
+    this.lastName = lastName;
+  }
+
+  /**
+   * @return role
+   */
+  public Role getRole() {
+
+    return this.role;
+  }
+
+  /**
+   * @param role the role to set
+   */
+  public void setRole(Role role) {
+
+    this.role = role;
+  }
+
+}

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/api/usecase/UcFindStaffMember.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/api/usecase/UcFindStaffMember.java
@@ -1,6 +1,8 @@
 package io.oasp.gastronomy.restaurant.staffmanagement.logic.api.usecase;
 
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberEto;
+import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.util.List;
 
@@ -26,5 +28,14 @@ public interface UcFindStaffMember {
   /**
    * @return {@link List} of all existing {@link StaffMemberEto staff members}.
    */
+  @Deprecated
   List<StaffMemberEto> findAllStaffMembers();
+
+  /**
+   * Returns a list of staff memberss matching the search criteria.
+   *
+   * @param criteria the {@link StaffMemberSearchCriteriaTo}.
+   * @return the {@link List} of matching {@link StaffMemberEto}s.
+   */
+  PaginatedListTo<StaffMemberEto> findStaffMemberEtos(StaffMemberSearchCriteriaTo criteria);
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/impl/StaffmanagementImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/impl/StaffmanagementImpl.java
@@ -4,8 +4,10 @@ import io.oasp.gastronomy.restaurant.general.logic.api.UseCase;
 import io.oasp.gastronomy.restaurant.general.logic.base.AbstractComponentFacade;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.Staffmanagement;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberEto;
+import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.usecase.UcFindStaffMember;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.usecase.UcManageStaffMember;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.util.List;
 
@@ -73,6 +75,7 @@ public class StaffmanagementImpl extends AbstractComponentFacade implements Staf
    * {@inheritDoc}
    */
   @Override
+  @Deprecated
   public List<StaffMemberEto> findAllStaffMembers() {
 
     return this.ucFindStaffMember.findAllStaffMembers();
@@ -103,5 +106,11 @@ public class StaffmanagementImpl extends AbstractComponentFacade implements Staf
   public void deleteStaffMember(Long staffMemberId) {
 
     this.ucManageStaffMember.deleteStaffMember(staffMemberId);
+  }
+
+  @Override
+  public PaginatedListTo<StaffMemberEto> findStaffMemberEtos(StaffMemberSearchCriteriaTo criteria) {
+
+    return this.ucFindStaffMember.findStaffMemberEtos(criteria);
   }
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/impl/usecase/UcFindStaffMemberImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/impl/usecase/UcFindStaffMemberImpl.java
@@ -6,8 +6,10 @@ import io.oasp.gastronomy.restaurant.general.common.api.constants.PermissionCons
 import io.oasp.gastronomy.restaurant.general.logic.api.UseCase;
 import io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.api.StaffMemberEntity;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberEto;
+import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.usecase.UcFindStaffMember;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.base.usecase.AbstractStaffMemberUc;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,6 +61,7 @@ public class UcFindStaffMemberImpl extends AbstractStaffMemberUc implements UcFi
    */
   @Override
   @RolesAllowed(PermissionConstants.FIND_STAFF_MEMBER)
+  @Deprecated
   public List<StaffMemberEto> findAllStaffMembers() {
 
     List<StaffMemberEntity> members = getStaffMemberDao().findAll();
@@ -87,6 +90,20 @@ public class UcFindStaffMemberImpl extends AbstractStaffMemberUc implements UcFi
   private StaffMemberEto privateFindStaffMemberByLogin(String login) {
 
     return getBeanMapper().map(getStaffMemberDao().findByLogin(login), StaffMemberEto.class);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @RolesAllowed(PermissionConstants.FIND_STAFF_MEMBER)
+  public PaginatedListTo<StaffMemberEto> findStaffMemberEtos(StaffMemberSearchCriteriaTo criteria) {
+
+    // Uncomment next line in order to limit the maximum page size for the staff member search
+    // criteria.limitMaximumPageSize(MAXIMUM_HIT_LIMIT);
+
+    PaginatedListTo<StaffMemberEntity> offers = getStaffMemberDao().findStaffMembers(criteria);
+    return mapPaginatedEntityList(offers, StaffMemberEto.class);
   }
 
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/service/impl/rest/StaffmanagementRestServiceImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/service/impl/rest/StaffmanagementRestServiceImpl.java
@@ -2,7 +2,10 @@ package io.oasp.gastronomy.restaurant.staffmanagement.service.impl.rest;
 
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.Staffmanagement;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberEto;
+import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
+import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.usecase.UcFindStaffMember;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.usecase.UcManageStaffMember;
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 
 import java.util.List;
 
@@ -50,6 +53,7 @@ public class StaffmanagementRestServiceImpl {
    */
   @GET
   @Path("/")
+  @Deprecated
   public List<StaffMemberEto> getAllStaffMember() {
 
     return this.staffManagement.findAllStaffMembers();
@@ -101,5 +105,18 @@ public class StaffmanagementRestServiceImpl {
   public void deleteStaffMember(@PathParam("login") String login) {
 
     this.staffManagement.deleteStaffMemberByLogin(login);
+  }
+
+  /**
+   * Delegates to {@link UcFindStaffMember#findStaffMemberEtos}.
+   *
+   * @param searchCriteriaTo the pagination and search criteria to be used for finding staffmembers.
+   * @return the {@link PaginatedListTo list} of matching {@link StaffMemberEto}s.
+   */
+  @Path("/search")
+  @POST
+  public PaginatedListTo<StaffMemberEto> findStaffMembersByPost(StaffMemberSearchCriteriaTo searchCriteriaTo) {
+
+    return this.staffManagement.findStaffMemberEtos(searchCriteriaTo);
   }
 }

--- a/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceImpl.java
+++ b/oasp4j-samples/oasp4j-sample-core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceImpl.java
@@ -1,7 +1,5 @@
 package io.oasp.gastronomy.restaurant.tablemanagement.service.impl.rest;
 
-import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderCto;
-import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcFindOrderPosition;
 import io.oasp.gastronomy.restaurant.tablemanagement.common.api.Table;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.Tablemanagement;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableEto;
@@ -164,10 +162,10 @@ public class TablemanagementRestServiceImpl {
   }
 
   /**
-   * Delegates to {@link UcFindOrderPosition#findOrderPositions}.
+   * Delegates to {@link UcFindTable#findTableEtos}.
    *
-   * @param searchCriteriaTo the pagination and search criteria to be used for finding orders.
-   * @return the {@link PaginatedListTo list} of matching {@link OrderCto}s.
+   * @param searchCriteriaTo the pagination and search criteria to be used for finding tables.
+   * @return the {@link PaginatedListTo list} of matching {@link TableEto}s.
    */
   @Path("/table/search")
   @POST


### PR DESCRIPTION
In this PR, I added search methods with pagination support for offer, product and staffmember entities as we agreed upon in https://github.com/oasp/oasp4j/issues/261.

Old methods like getAllXXX were marked as deprecated and can be removed after the clients are adapted to the changes.

Some details I'd like to record here:
* I had to add the Comparable interface to the Money class because otherwise filtering offers by price range would have become very cumbersome.
* Concerns were raised about master data entities and pagination/hit limit. There is no hit limit when removing the line `criteria.limitMaximumPageSize(MAXIMUM_HIT_LIMIT);` like in UcFindStaffMemberImpl#findStaffMemberEtos and not specifying a pagination.size attribute in the POST payload.

 If you have any feedback, please share.