### PR TITLE
Upgrade to Spring Boot 1.2.7.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <port.range>81</port.range>
     <oasp.gpg.keyname>joerg.hohwiller@capgemini.com</oasp.gpg.keyname>
     <oasp.flatten.mode>oss</oasp.flatten.mode>
-    <spring.boot.version>1.2.6.RELEASE</spring.boot.version>
+    <spring.boot.version>1.2.7.RELEASE</spring.boot.version>
   </properties>
 
   <build>


### PR DESCRIPTION
The next fix release is available. We can upgrade to the new version