### PR TITLE
Simplified package name of Configuration classes of sample-app to *.g…

### DIFF
--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/BeansBatchConfig.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/BeansBatchConfig.java
@@ -1,4 +1,4 @@
-package io.oasp.gastronomy.restaurant.general.common.impl.configuration;
+package io.oasp.gastronomy.restaurant.general.configuration;
 
 /**
  * This class contains the configuration like jobLauncher,Jobrepository etc.

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/BeansDozerConfiguration.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/BeansDozerConfiguration.java
@@ -1,4 +1,4 @@
-package io.oasp.gastronomy.restaurant.general.common.impl.configuration;
+package io.oasp.gastronomy.restaurant.general.configuration;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/DefaultRolesPrefixPostProcessor.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/DefaultRolesPrefixPostProcessor.java
@@ -1,4 +1,4 @@
-package io.oasp.gastronomy.restaurant.general.common.impl.configuration;
+package io.oasp.gastronomy.restaurant.general.configuration;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/ServiceConfiguration.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/ServiceConfiguration.java
@@ -1,4 +1,4 @@
-package io.oasp.gastronomy.restaurant.general.common.impl.configuration;
+package io.oasp.gastronomy.restaurant.general.configuration;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/WebConfig.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/WebConfig.java
@@ -1,4 +1,4 @@
-package io.oasp.gastronomy.restaurant.general.common.impl.configuration;
+package io.oasp.gastronomy.restaurant.general.configuration;
 
 import io.oasp.module.logging.common.api.DiagnosticContextFacade;
 import io.oasp.module.logging.common.impl.DiagnosticContextFacadeImpl;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/WebSecurityConfig.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/WebSecurityConfig.java
@@ -1,4 +1,4 @@
-package io.oasp.gastronomy.restaurant.general.common.impl.configuration;
+package io.oasp.gastronomy.restaurant.general.configuration;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;


### PR DESCRIPTION
We propose to change the package name of the Configuration classes in the apps from the rather obscure  

package io.oasp.gastronomy.restaurant.general.common.impl.configuration 

to

package io.oasp.gastronomy.restaurant.general.configuration

This would be valid for the application templates as well