### PR TITLE
Adding abstract persistence application entity

### DIFF
--- a/modules/jpa/src/main/java/io/oasp/module/jpa/dataaccess/api/AbstractPersistenceEntity.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/dataaccess/api/AbstractPersistenceEntity.java
@@ -16,6 +16,7 @@ import javax.persistence.Version;
  * @author rjoeris
  */
 @MappedSuperclass
+@Deprecated
 public abstract class AbstractPersistenceEntity implements MutablePersistenceEntity<Long> {
 
   private static final long serialVersionUID = 1L;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/dataaccess/api/AbstractPersistenceApplicationEntity.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/dataaccess/api/AbstractPersistenceApplicationEntity.java
@@ -1,0 +1,110 @@
+package io.oasp.gastronomy.restaurant.general.dataaccess.api;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.Transient;
+import javax.persistence.Version;
+
+import io.oasp.module.jpa.dataaccess.api.MutablePersistenceEntity;
+
+/**
+ * This is a customized implementation of the class {@link io.oasp.module.jpa.dataaccess.api.AbstractPersistenceEntity}.
+ * For this sample application is just a copy
+ *
+ * @author jhcore
+ */
+@MappedSuperclass
+public class AbstractPersistenceApplicationEntity implements MutablePersistenceEntity<Long> {
+
+  private static final long serialVersionUID = 1L;
+
+  /** @see #getId() */
+  private Long id;
+
+  /** @see #getModificationCounter() */
+  private int modificationCounter;
+
+  /** @see #getRevision() */
+  private Number revision;
+
+  /**
+   * The constructor.
+   */
+  public AbstractPersistenceApplicationEntity() {
+
+    super();
+  }
+
+  @Override
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  public Long getId() {
+
+    return this.id;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setId(Long id) {
+
+    this.id = id;
+  }
+
+  @Override
+  @Version
+  public int getModificationCounter() {
+
+    return this.modificationCounter;
+  }
+
+  @Override
+  public void setModificationCounter(int version) {
+
+    this.modificationCounter = version;
+  }
+
+  @Override
+  @Transient
+  public Number getRevision() {
+
+    return this.revision;
+  }
+
+  /**
+   * @param revision the revision to set
+   */
+  @Override
+  public void setRevision(Number revision) {
+
+    this.revision = revision;
+  }
+
+  @Override
+  public String toString() {
+
+    StringBuilder buffer = new StringBuilder();
+    toString(buffer);
+    return buffer.toString();
+  }
+
+  /**
+   * Method to extend {@link #toString()} logic.
+   *
+   * @param buffer is the {@link StringBuilder} where to {@link StringBuilder#append(Object) append} the string
+   *        representation.
+   */
+  protected void toString(StringBuilder buffer) {
+
+    buffer.append(getClass().getSimpleName());
+    if (this.id != null) {
+      buffer.append("[id=");
+      buffer.append(this.id);
+      buffer.append("]");
+    }
+  }
+
+}

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/dataaccess/api/ApplicationPersistenceEntity.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/dataaccess/api/ApplicationPersistenceEntity.java
@@ -1,9 +1,8 @@
 package io.oasp.gastronomy.restaurant.general.dataaccess.api;
 
-import io.oasp.gastronomy.restaurant.general.common.api.ApplicationEntity;
-import io.oasp.module.jpa.dataaccess.api.AbstractPersistenceEntity;
-
 import javax.persistence.MappedSuperclass;
+
+import io.oasp.gastronomy.restaurant.general.common.api.ApplicationEntity;
 
 /**
  * Abstract Entity for all Entities with an id and a version field.
@@ -12,7 +11,8 @@ import javax.persistence.MappedSuperclass;
  * @author rjoeris
  */
 @MappedSuperclass
-public abstract class ApplicationPersistenceEntity extends AbstractPersistenceEntity implements ApplicationEntity {
+public abstract class ApplicationPersistenceEntity extends AbstractPersistenceApplicationEntity
+    implements ApplicationEntity {
 
   private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
OASP4J Sample Application:

- Create the class AbstractPersistenceApplicationEntity (copy of the deprecate class AbstractPersistenceEntity)

- Do the class AbstractPersistenceEntity of the module jpa as deprecated

- Now the class ApplicationPersistenceEntity extends a the new class called  AbstractPersistenceApplicationEntity (customization of the class AbstractPersistenceEntity)