### PR TITLE
Modified build to generate bootified war

### DIFF
--- a/samples/server/pom.xml
+++ b/samples/server/pom.xml
@@ -129,12 +129,18 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <mainClass>io.oasp.gastronomy.restaurant.SpringBootApp</mainClass>
-          <classifier>bootified</classifier>
-          <finalName>${project.artifactId}</finalName>
-          <layout>WAR</layout>
-        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+            <configuration>
+              <mainClass>io.oasp.gastronomy.restaurant.SpringBootApp</mainClass>
+              <classifier>bootified</classifier>
+              <finalName>${project.artifactId}</finalName>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Related PR to [yammer issue](https://www.yammer.com/capgemini.com/#/Threads/show?threadId=736204230). 
Changes build in server\pom.xml to generate an additional bootified war file that can be executed with:
oasp4j\samples\server\target> java -jar oasp4j-sample-server-bootified.war
@hohwille can you check the change?
