### PR TITLE
fixes usage of cobigen generated test data builder by excluding commo…

### DIFF
--- a/templates/server/build.xml
+++ b/templates/server/build.xml
@@ -104,6 +104,7 @@
         <exclude name="*management"/>
         <exclude name="*management/*"/>
         <exclude name="*management/**/*"/>
+        <exclude name="*common/builders/*"/>
         <!-- exclude application specific Money class and related classes -->
         <exclude name="**/*Money*.java"/>
       </fileset>


### PR DESCRIPTION
…n.builders package


As the generated test data builders reside in gastronomy.restaurant.common.builders one needs to exclude this package for the archetype generation in server template. This would also be an issue for other custom generated folders that do not match the already excluded ones and should be discussed further.