### PR TITLE
#461: update performed

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,6 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <cxf.version>3.1.6</cxf.version>
+    <mmm.util.version>7.3.0</mmm.util.version>
     <oasp.gpg.keyname>joerg.hohwiller@capgemini.com</oasp.gpg.keyname>
     <oasp.flatten.mode>bom</oasp.flatten.mode>
   </properties>
@@ -27,6 +28,14 @@
   <dependencyManagement>
     <dependencies>
       <!-- *** EXTERNAL DEPENDENCIES *** -->
+      <!-- BOM for localization -->
+      <dependency>
+          <groupId>net.sf.m-m-m</groupId>
+        <artifactId>mmm-l10n-bom</artifactId>
+        <version>1.4.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- JSR 250 for component/bean lifecycle management -->
       <dependency>
         <groupId>javax.annotation</groupId>
@@ -55,7 +64,37 @@
       <dependency>
         <groupId>net.sf.m-m-m</groupId>
         <artifactId>mmm-util-core</artifactId>
-        <version>7.0.0</version>
+        <version>${mmm.util.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sf.m-m-m</groupId>
+        <artifactId>mmm-util-io</artifactId>
+        <version>${mmm.util.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sf.m-m-m</groupId>
+        <artifactId>mmm-util-entity</artifactId>
+        <version>${mmm.util.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sf.m-m-m</groupId>
+        <artifactId>mmm-util-pojo</artifactId>
+        <version>${mmm.util.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sf.m-m-m</groupId>
+        <artifactId>mmm-util-validation</artifactId>
+        <version>${mmm.util.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sf.m-m-m</groupId>
+        <artifactId>mmm-util-search</artifactId>
+        <version>${mmm.util.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sf.m-m-m</groupId>
+        <artifactId>mmm-util-cli</artifactId>
+        <version>${mmm.util.version}</version>
       </dependency>
       <!-- Library with advanced collection support -->
       <dependency>

--- a/modules/basic/pom.xml
+++ b/modules/basic/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>net.sf.m-m-m</groupId>
-      <artifactId>mmm-util-core</artifactId>
+      <artifactId>mmm-util-entity</artifactId>
       </dependency>
   </dependencies>
 </project>

--- a/modules/beanmapping/pom.xml
+++ b/modules/beanmapping/pom.xml
@@ -25,7 +25,7 @@
     </dependency>
     <dependency>
       <groupId>net.sf.m-m-m</groupId>
-      <artifactId>mmm-util-core</artifactId>
+      <artifactId>mmm-util-entity</artifactId>
     </dependency>
 
     <!-- Orika (not yet default but will once replace dozer) -->

--- a/modules/jpa/pom.xml
+++ b/modules/jpa/pom.xml
@@ -40,6 +40,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.sf.m-m-m</groupId>
+      <artifactId>mmm-util-search</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.oasp.java.modules</groupId>

--- a/modules/rest/pom.xml
+++ b/modules/rest/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>net.sf.m-m-m</groupId>
-      <artifactId>mmm-util-core</artifactId>
+      <artifactId>mmm-util-validation</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
Here is the update for #461. In order not to get confused by the diff. I modularized `mmm-util-core` due to demands from OASP (Iwan, Angel, etc.):
https://github.com/m-m-m/util/issues/169

This enables the OASP to get rid of some mmm dependencies step by step in the future.
Some people wanted to reimplement the entity stuff in `oasp4j-basic`. This can now be done and we could then get rid of `mmm-util-entity`. Further it should be also easy to get rid of `mmm-util-search` and `mmm-util-validation` if someone is up to it.
However, as a first step we should do this update that is required as enabler for further steps and also brings some bugfixes and new features actually demanded by OASP and implemented by mmm community :)