### PR TITLE
Fix for #384, #477: Cleanup Sample App Dependencies

### DIFF
--- a/samples/core/pom.xml
+++ b/samples/core/pom.xml
@@ -213,6 +213,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -238,6 +239,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-ws</artifactId>
+      <exclusions>
+      <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-web</artifactId>
+        </exclusion></exclusions>
     </dependency>
 
     <dependency>

--- a/samples/core/pom.xml
+++ b/samples/core/pom.xml
@@ -240,10 +240,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-ws</artifactId>
       <exclusions>
-      <exclusion>
+        <exclusion>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-web</artifactId>
-        </exclusion></exclusions>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -269,7 +270,7 @@
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
       <version>1.3.0</version>
-    <scope>test</scope>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/SpringBootBatchTestApp.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/SpringBootBatchTestApp.java
@@ -3,24 +3,29 @@ package io.oasp.gastronomy.restaurant;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration;
 import org.springframework.boot.orm.jpa.EntityScan;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 
 import io.oasp.module.jpa.dataaccess.api.AdvancedRevisionEntity;
 
-//@SpringBootApplication(exclude = { SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class })
-@SpringBootApplication(exclude = { EndpointAutoConfiguration.class })
+@SpringBootApplication(exclude = {
+		EndpointAutoConfiguration.class,
+		SecurityAutoConfiguration.class,
+		SecurityFilterAutoConfiguration.class,
+		})
 @EntityScan(basePackages = { "io.oasp.gastronomy.restaurant" }, basePackageClasses = { AdvancedRevisionEntity.class })
-@EnableGlobalMethodSecurity(jsr250Enabled = true)
-public class SpringBootApp {
+@EnableGlobalMethodSecurity(jsr250Enabled = false)
+public class SpringBootBatchTestApp {
 
   /**
    * Entry point for spring-boot based app
    *
    * @param args - arguments
    */
-  public static void main(String[] args) {
+	  public static void main(String[] args) {
 
-    SpringApplication.run(SpringBootApp.class, args);
-  }
+		    SpringApplication.run(SpringBootTestApp.class, args);
+	  }
 }

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/SpringBootTestApp.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/SpringBootTestApp.java
@@ -3,29 +3,24 @@ package io.oasp.gastronomy.restaurant;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration;
 import org.springframework.boot.orm.jpa.EntityScan;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 
 import io.oasp.module.jpa.dataaccess.api.AdvancedRevisionEntity;
 
-@SpringBootApplication(exclude = {
-		EndpointAutoConfiguration.class,
-		SecurityAutoConfiguration.class,
-		SecurityFilterAutoConfiguration.class,
-		})
+//@SpringBootApplication(exclude = { SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class })
+@SpringBootApplication(exclude = { EndpointAutoConfiguration.class })
 @EntityScan(basePackages = { "io.oasp.gastronomy.restaurant" }, basePackageClasses = { AdvancedRevisionEntity.class })
-@EnableGlobalMethodSecurity(jsr250Enabled = false)
-public class SpringBootBatchApp {
+@EnableGlobalMethodSecurity(jsr250Enabled = true)
+public class SpringBootTestApp {
 
   /**
    * Entry point for spring-boot based app
    *
    * @param args - arguments
    */
-	  public static void main(String[] args) {
+  public static void main(String[] args) {
 
-		    SpringApplication.run(SpringBootApp.class, args);
-	  }
+    SpringApplication.run(SpringBootTestApp.class, args);
+  }
 }

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/OfferManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/OfferManagementTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import io.oasp.gastronomy.restaurant.SpringBootApp;
+import io.oasp.gastronomy.restaurant.SpringBootTestApp;
 import io.oasp.gastronomy.restaurant.general.common.TestUtil;
 import io.oasp.gastronomy.restaurant.general.common.api.constants.PermissionConstants;
 import io.oasp.gastronomy.restaurant.general.common.api.datatype.Money;
@@ -31,7 +31,7 @@ import io.oasp.module.test.common.base.ComponentTest;
  *
  * @since dev
  */
-@SpringApplicationConfiguration(classes = { SpringBootApp.class })
+@SpringApplicationConfiguration(classes = { SpringBootTestApp.class })
 @WebAppConfiguration
 public class OfferManagementTest extends ComponentTest {
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductImportJobTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductImportJobTest.java
@@ -1,6 +1,6 @@
 package io.oasp.gastronomy.restaurant.offermanagement.batch.impl.productimport;
 
-import io.oasp.gastronomy.restaurant.SpringBootBatchApp;
+import io.oasp.gastronomy.restaurant.SpringBootBatchTestApp;
 import io.oasp.gastronomy.restaurant.general.common.AbstractSpringBatchIntegrationTest;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.Offermanagement;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.DrinkEto;
@@ -25,7 +25,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
  * End-To-End test job "import offer management from csv"
  *
  */
-@SpringApplicationConfiguration(classes= { SpringBootBatchApp.class }, locations = { "classpath:config/app/batch/beans-productimport.xml" })
+@SpringApplicationConfiguration(classes= { SpringBootBatchTestApp.class }, locations = { "classpath:config/app/batch/beans-productimport.xml" })
 @WebAppConfiguration
 public class ProductImportJobTest extends AbstractSpringBatchIntegrationTest {
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import io.oasp.gastronomy.restaurant.SpringBootApp;
+import io.oasp.gastronomy.restaurant.SpringBootTestApp;
 import io.oasp.gastronomy.restaurant.general.common.TestUtil;
 import io.oasp.gastronomy.restaurant.general.common.api.constants.PermissionConstants;
 import io.oasp.gastronomy.restaurant.offermanagement.common.api.Product;
@@ -30,7 +30,7 @@ import io.oasp.module.test.common.base.ComponentTest;
  *
  * @since dev
  */
-@SpringApplicationConfiguration(classes = { SpringBootApp.class })
+@SpringApplicationConfiguration(classes = { SpringBootTestApp.class })
 @WebAppConfiguration
 public class ProductManagementTest extends ComponentTest {
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/batch/impl/billexport/BillExportJobTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/batch/impl/billexport/BillExportJobTest.java
@@ -22,14 +22,14 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import io.oasp.gastronomy.restaurant.SpringBootBatchApp;
+import io.oasp.gastronomy.restaurant.SpringBootBatchTestApp;
 import io.oasp.gastronomy.restaurant.general.common.AbstractSpringBatchIntegrationTest;
 
 /**
  * End-To-End test job "import offer management from csv"
  *
  */
-@SpringApplicationConfiguration(classes = { SpringBootBatchApp.class }, locations = {
+@SpringApplicationConfiguration(classes = { SpringBootBatchTestApp.class }, locations = {
 "classpath:/config/app/batch/beans-billexport.xml" })
 @WebAppConfiguration
 public class BillExportJobTest extends AbstractSpringBatchIntegrationTest {

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/dataaccess/impl/dao/BillDaoTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/dataaccess/impl/dao/BillDaoTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import io.oasp.gastronomy.restaurant.SpringBootApp;
+import io.oasp.gastronomy.restaurant.SpringBootTestApp;
 import io.oasp.gastronomy.restaurant.common.builders.BillEntityBuilder;
 import io.oasp.gastronomy.restaurant.general.common.api.datatype.Money;
 import io.oasp.gastronomy.restaurant.salesmanagement.dataaccess.api.BillEntity;
@@ -24,7 +24,7 @@ import io.oasp.module.test.common.base.ComponentTest;
  *
  */
 @Transactional
-@SpringApplicationConfiguration(classes = { SpringBootApp.class })
+@SpringApplicationConfiguration(classes = { SpringBootTestApp.class })
 @WebAppConfiguration
 public class BillDaoTest extends ComponentTest {
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/dataaccess/impl/dao/DrinkDaoTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/dataaccess/impl/dao/DrinkDaoTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import io.oasp.gastronomy.restaurant.SpringBootApp;
+import io.oasp.gastronomy.restaurant.SpringBootTestApp;
 import io.oasp.gastronomy.restaurant.common.builders.DrinkEntityBuilder;
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.DrinkEntity;
 import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.dao.DrinkDao;
@@ -26,7 +26,7 @@ import io.oasp.module.test.common.base.ComponentTest;
  *
  */
 
-@SpringApplicationConfiguration(classes = { SpringBootApp.class })
+@SpringApplicationConfiguration(classes = { SpringBootTestApp.class })
 @WebAppConfiguration
 public class DrinkDaoTest extends ComponentTest {
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesManagementTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import io.oasp.gastronomy.restaurant.SpringBootApp;
+import io.oasp.gastronomy.restaurant.SpringBootTestApp;
 import io.oasp.gastronomy.restaurant.common.builders.OrderEtoBuilder;
 import io.oasp.gastronomy.restaurant.common.builders.OrderPositionEtoBuilder;
 import io.oasp.gastronomy.restaurant.general.common.DbTestHelper;
@@ -28,7 +28,7 @@ import io.oasp.module.test.common.base.ComponentTest;
  * This is the test-case of {@link Salesmanagement}.
  *
  */
-@SpringApplicationConfiguration(classes = { SpringBootApp.class })
+@SpringApplicationConfiguration(classes = { SpringBootTestApp.class })
 @WebAppConfiguration
 public class SalesManagementTest extends ComponentTest {
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementHttpRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementHttpRestServiceTest.java
@@ -41,7 +41,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.client.RestTemplate;
 
-import io.oasp.gastronomy.restaurant.SpringBootApp;
+import io.oasp.gastronomy.restaurant.SpringBootTestApp;
 import io.oasp.gastronomy.restaurant.common.builders.OrderPositionEtoBuilder;
 import io.oasp.gastronomy.restaurant.general.common.base.AbstractRestServiceTest;
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.OrderPosition;
@@ -56,7 +56,7 @@ import io.oasp.gastronomy.restaurant.salesmanagement.service.api.rest.Salesmanag
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = { SpringBootApp.class, SalesmanagementRestTestConfiguration.class })
+@SpringApplicationConfiguration(classes = { SpringBootTestApp.class, SalesmanagementRestTestConfiguration.class })
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
 
 public class SalesmanagementHttpRestServiceTest extends AbstractRestServiceTest {

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceTest.java
@@ -25,7 +25,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import io.oasp.gastronomy.restaurant.SpringBootApp;
+import io.oasp.gastronomy.restaurant.SpringBootTestApp;
 import io.oasp.gastronomy.restaurant.general.common.base.AbstractRestServiceTest;
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.datatype.OrderPositionState;
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.datatype.OrderState;
@@ -43,7 +43,7 @@ import io.oasp.module.jpa.common.api.to.PaginationTo;
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = { SpringBootApp.class, SalesmanagementRestTestConfiguration.class })
+@SpringApplicationConfiguration(classes = { SpringBootTestApp.class, SalesmanagementRestTestConfiguration.class })
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
 
 public class SalesmanagementRestServiceTest extends AbstractRestServiceTest {

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementTest.java
@@ -13,7 +13,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import io.oasp.gastronomy.restaurant.SpringBootApp;
+import io.oasp.gastronomy.restaurant.SpringBootTestApp;
 import io.oasp.gastronomy.restaurant.common.builders.OrderEtoBuilder;
 import io.oasp.gastronomy.restaurant.common.builders.OrderPositionEtoBuilder;
 import io.oasp.gastronomy.restaurant.general.common.DbTestHelper;
@@ -34,7 +34,7 @@ import io.oasp.module.test.common.base.ComponentTest;
  *
  */
 
-@SpringApplicationConfiguration(classes = { SpringBootApp.class })
+@SpringApplicationConfiguration(classes = { SpringBootTestApp.class })
 @WebAppConfiguration
 public class TablemanagementTest extends ComponentTest {
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceTest.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import io.oasp.gastronomy.restaurant.SpringBootApp;
+import io.oasp.gastronomy.restaurant.SpringBootTestApp;
 import io.oasp.gastronomy.restaurant.common.builders.TableEtoBuilder;
 import io.oasp.gastronomy.restaurant.general.common.base.AbstractRestServiceTest;
 import io.oasp.gastronomy.restaurant.tablemanagement.common.api.datatype.TableState;
@@ -24,7 +24,7 @@ import io.oasp.module.jpa.common.api.to.PaginatedListTo;
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = SpringBootApp.class)
+@SpringApplicationConfiguration(classes = SpringBootTestApp.class)
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
 // , locations = {"file:src/test/resources/config" })
 

--- a/samples/server/pom.xml
+++ b/samples/server/pom.xml
@@ -23,6 +23,14 @@
       <artifactId>oasp4j-sample-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+    <groupId>javax.servlet</groupId>
+    <artifactId>javax.servlet-api</artifactId>
+    </dependency>
  </dependencies>
 
   <profiles>

--- a/samples/server/src/main/java/io/oasp/gastronomy/restaurant/SpringBootApp.java
+++ b/samples/server/src/main/java/io/oasp/gastronomy/restaurant/SpringBootApp.java
@@ -1,0 +1,26 @@
+package io.oasp.gastronomy.restaurant;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.orm.jpa.EntityScan;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+
+import io.oasp.module.jpa.dataaccess.api.AdvancedRevisionEntity;
+
+//@SpringBootApplication(exclude = { SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class })
+@SpringBootApplication(exclude = { EndpointAutoConfiguration.class })
+@EntityScan(basePackages = { "io.oasp.gastronomy.restaurant" }, basePackageClasses = { AdvancedRevisionEntity.class })
+@EnableGlobalMethodSecurity(jsr250Enabled = true)
+public class SpringBootApp {
+
+  /**
+   * Entry point for spring-boot based app
+   *
+   * @param args - arguments
+   */
+  public static void main(String[] args) {
+
+    SpringApplication.run(SpringBootApp.class, args);
+  }
+}

--- a/samples/server/src/main/java/io/oasp/gastronomy/restaurant/SpringBootBatchApp.java
+++ b/samples/server/src/main/java/io/oasp/gastronomy/restaurant/SpringBootBatchApp.java
@@ -1,0 +1,28 @@
+package io.oasp.gastronomy.restaurant;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration;
+import org.springframework.boot.orm.jpa.EntityScan;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+
+import io.oasp.module.jpa.dataaccess.api.AdvancedRevisionEntity;
+
+@SpringBootApplication(exclude = { EndpointAutoConfiguration.class, SecurityAutoConfiguration.class,
+SecurityFilterAutoConfiguration.class, })
+@EntityScan(basePackages = { "io.oasp.gastronomy.restaurant" }, basePackageClasses = { AdvancedRevisionEntity.class })
+@EnableGlobalMethodSecurity(jsr250Enabled = false)
+public class SpringBootBatchApp {
+
+  /**
+   * Entry point for spring-boot based app
+   *
+   * @param args - arguments
+   */
+  public static void main(String[] args) {
+
+    SpringApplication.run(SpringBootApp.class, args);
+  }
+}

--- a/samples/server/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/ServletInitializer.java
+++ b/samples/server/src/main/java/io/oasp/gastronomy/restaurant/general/configuration/ServletInitializer.java
@@ -1,11 +1,11 @@
 package io.oasp.gastronomy.restaurant.general.configuration;
 
-import io.oasp.gastronomy.restaurant.SpringBootApp;
-
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.web.SpringBootServletInitializer;
 import org.springframework.context.annotation.Configuration;
+
+import io.oasp.gastronomy.restaurant.SpringBootApp;
 
 /**
  * This auto configuration will be used by spring boot to enable traditional deployment to a servlet container. You may


### PR DESCRIPTION
Regarding #384:
Moved server dependencies from Core to Server.
Namely:
- `spring-boot-starter-web`
- `javax.servlet-api`

Both are still included in Core, but with scope "provided" only. This is necessary for compiling and testing.

The following classes have been create in _core test_:
- `SpringBootApp.java`
- `SpringBootBatchApp.java`

The following classes have been create in _sample server_:
- `SpringBootTestApp.java`
- `SpringBootBatchTestApp.java`

Consider the following list to see which problems from #384 are solved by this PR:
- [x]    move the server dependencies (tomcat, etc.) and according code (launcher) to server.
- [ ]    move the batch dependencies (spring-batch, etc.) and according code (batch layer code but not logic layer stuff for batches) to batch.
- [x]    make the core module a regular JAR (not bootified) (has already been solved; #446 )
- [x]   make the server module a bootified WAR (has already been solved; #446 )
- [ ]   make the batch module a JAR but also provide a ZIP or TGZ as classified side-artifact.
- [ ]  create api module and extract Interfaces from REST-Services and move to that module.

(Unmarked bullet points will be solved later)

Regarding #477:
The sample app should only be started via executing the bootified server JAR. In the server project run:
`java -jar target/oasp4j-sample-server-bootified.war`

I request to close #478 and to merge this PR instead.
