### PR TITLE
changes in oasp4j pom.xml and template server pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,30 +80,7 @@
         </executions>
       </plugin>
 
-      <!-- http://mojo.codehaus.org/flatten-maven-plugin/ -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>flatten-maven-plugin</artifactId>
-        <configuration>
-          <flattenMode>${oasp.flatten.mode}</flattenMode>
-        </configuration>
-        <executions>
-          <execution>
-            <id>flatten</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>flatten</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>flatten.clean</id>
-            <phase>clean</phase>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+     
 
       <!-- avoid version in local war files, exclude development properties from WARs -->
       <plugin>
@@ -282,6 +259,30 @@
           <artifactId>dependency-check-maven</artifactId>
           <version>1.3.6</version>
         </plugin>
+		 <!-- http://mojo.codehaus.org/flatten-maven-plugin/ -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <flattenMode>${oasp.flatten.mode}</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/templates/server/pom.xml
+++ b/templates/server/pom.xml
@@ -58,7 +58,7 @@
         <version>2.2</version>
       </extension>
     </extensions>
-
+<pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -117,6 +117,7 @@
         </executions>
       </plugin>
     </plugins>
+	</pluginManagement>
   </build>
 
 </project>


### PR DESCRIPTION
While setting up Devonfw first time if we import "workspaces/examples/oasp4j/samples” projects as maven projects in eclipse, it gives build error  as "Plugin execution not covered by lifecycle configuration: org.apache.maven.plugins:maven-antrun-plugin:1.7:run (execution: copy-sources, phase: compile)".This same error occurs for flatten maven  plugin.
To resolve this, both the plugins are enclosed within pluginManagement tag in oasp4j pom.xml and oasp4j-template-server pom.xml.