### PR TITLE
Base test classes

### DIFF
--- a/modules/test/src/main/java/io/oasp/module/test/common/base/BaseTest.java
+++ b/modules/test/src/main/java/io/oasp/module/test/common/base/BaseTest.java
@@ -1,0 +1,69 @@
+package io.oasp.module.test.common.base;
+
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * This is the {@code abstract} base class for all tests. In most cases it will be convenient to extend this class. <br>
+ * <br/>
+ * Although it does not contain abstract methods, the class itself is declared {@code abstract} to clarify its purpose.
+ * <br/>
+ * <br/>
+ * This class provides {@code final} methods {@link #setUp()} and {@link #tearDown()} which call {@code protected}
+ * methods {@link #doSetUp()} and {@link #doTearDown()} internally. <br/>
+ * Both methods {@link #doSetUp()} and {@link #doTearDown()} are left empty here. If some default behaviour is desired
+ * during test setup or teardown these methods should be overridden by the subclass. <br/>
+ * Implementations <b>must</b> call the super implementation. This call should always happen at the beginning of the
+ * implementation. This helps to avoid confusion of call orders. <br/>
+ * <br/>
+ * The following listing should clarify the intention:
+ *
+ * <pre>
+ * public class MyTest extends BaseTest {
+ *
+ *   &#64;Override
+ *   protected void doSetUp() {
+ *
+ *     super.doSetUp();
+ *     // ... my code
+ *   }
+ * }
+ * </pre>
+ *
+ * @author shuber, jmolinar
+ */
+public abstract class BaseTest extends Assertions {
+
+  /**
+   * Suggests to use {@link #doSetUp()} method before each tests.
+   */
+  @Before
+  public final void setUp() {
+
+    doSetUp();
+  }
+
+  /**
+   * Suggests to use {@link #doTearDown()} method before each tests.
+   */
+  @After
+  public final void tearDown() {
+
+    doTearDown();
+  }
+
+  /**
+   * Provides initialization previous to the creation of the text fixture.
+   */
+  protected void doSetUp() {
+
+  }
+
+  /**
+   * Provides clean up after tests.
+   */
+  protected void doTearDown() {
+
+  }
+}

--- a/modules/test/src/main/java/io/oasp/module/test/common/base/BaseTest.java
+++ b/modules/test/src/main/java/io/oasp/module/test/common/base/BaseTest.java
@@ -47,10 +47,10 @@ public abstract class BaseTest extends Assertions {
   public final void setUp() {
 
     // Simply sets INITIALIZED to true when setUp is called for the first time.
+    doSetUp(INITIALIZED);
     if (!INITIALIZED) {
       INITIALIZED = true;
     }
-    doSetUp(INITIALIZED);
   }
 
   /**

--- a/modules/test/src/main/java/io/oasp/module/test/common/base/BaseTest.java
+++ b/modules/test/src/main/java/io/oasp/module/test/common/base/BaseTest.java
@@ -47,7 +47,7 @@ public abstract class BaseTest extends Assertions {
   public final void setUp() {
 
     // Simply sets INITIALIZED to true when setUp is called for the first time.
-    doSetUp(INITIALIZED);
+    doSetUp();
     if (!INITIALIZED) {
       INITIALIZED = true;
     }
@@ -63,9 +63,18 @@ public abstract class BaseTest extends Assertions {
   }
 
   /**
+   * @return {@code true} if this JUnit class is invoked for the first time (first test method is called), {@code false}
+   *         otherwise (if this is a subsequent invocation).
+   */
+  protected boolean isInitialSetup() {
+
+    return INITIALIZED;
+  }
+
+  /**
    * Provides initialization previous to the creation of the text fixture.
    */
-  protected void doSetUp(boolean initialized) {
+  protected void doSetUp() {
 
   }
 

--- a/modules/test/src/main/java/io/oasp/module/test/common/base/BaseTest.java
+++ b/modules/test/src/main/java/io/oasp/module/test/common/base/BaseTest.java
@@ -34,6 +34,11 @@ import org.junit.Before;
  * @author shuber, jmolinar
  */
 public abstract class BaseTest extends Assertions {
+  /**
+   * Indicates if the test class is to be set up for the first time. {@code true} indicates that the class has already
+   * been set up (e.g., database setup) for the execution of an preceding test method.
+   */
+  protected static boolean INITIALIZED = false;
 
   /**
    * Suggests to use {@link #doSetUp()} method before each tests.
@@ -41,7 +46,11 @@ public abstract class BaseTest extends Assertions {
   @Before
   public final void setUp() {
 
-    doSetUp();
+    // Simply sets INITIALIZED to true when setUp is called for the first time.
+    if (!INITIALIZED) {
+      INITIALIZED = true;
+    }
+    doSetUp(INITIALIZED);
   }
 
   /**
@@ -56,7 +65,7 @@ public abstract class BaseTest extends Assertions {
   /**
    * Provides initialization previous to the creation of the text fixture.
    */
-  protected void doSetUp() {
+  protected void doSetUp(boolean initialized) {
 
   }
 

--- a/modules/test/src/main/java/io/oasp/module/test/common/base/ComponentTest.java
+++ b/modules/test/src/main/java/io/oasp/module/test/common/base/ComponentTest.java
@@ -1,14 +1,13 @@
 package io.oasp.module.test.common.base;
 
-import io.oasp.module.test.common.api.category.CategoryComponentTest;
-
-import org.assertj.core.api.Assertions;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
+
+import io.oasp.module.test.common.api.category.CategoryComponentTest;
 
 /**
  * This is the abstract base class for a component test. You are free to create your component tests as you like just by
@@ -21,6 +20,6 @@ import org.springframework.test.context.transaction.TransactionalTestExecutionLi
 @RunWith(SpringJUnit4ClassRunner.class)
 @TestExecutionListeners({ TransactionalTestExecutionListener.class, DependencyInjectionTestExecutionListener.class })
 @Category(CategoryComponentTest.class)
-public abstract class ComponentTest extends Assertions {
+public abstract class ComponentTest extends BaseTest {
 
 }

--- a/modules/test/src/main/java/io/oasp/module/test/common/base/ModuleTest.java
+++ b/modules/test/src/main/java/io/oasp/module/test/common/base/ModuleTest.java
@@ -1,9 +1,8 @@
 package io.oasp.module.test.common.base;
 
-import io.oasp.module.test.common.api.category.CategoryModuleTest;
-
-import org.assertj.core.api.Assertions;
 import org.junit.experimental.categories.Category;
+
+import io.oasp.module.test.common.api.category.CategoryModuleTest;
 
 /**
  * This is the abstract base class for a module test. You are free to create your module tests as you like just by
@@ -14,6 +13,6 @@ import org.junit.experimental.categories.Category;
  *
  */
 @Category(CategoryModuleTest.class)
-public abstract class ModuleTest extends Assertions {
+public abstract class ModuleTest extends BaseTest {
 
 }

--- a/modules/test/src/main/java/io/oasp/module/test/common/base/SubsystemTest.java
+++ b/modules/test/src/main/java/io/oasp/module/test/common/base/SubsystemTest.java
@@ -1,14 +1,13 @@
 package io.oasp.module.test.common.base;
 
-import io.oasp.module.test.common.api.category.CategorySubsystemTest;
-
-import org.assertj.core.api.Assertions;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
+
+import io.oasp.module.test.common.api.category.CategorySubsystemTest;
 
 /**
  * This is the abstract base class for an integration test. You are free to create your integration tests as you like
@@ -21,6 +20,6 @@ import org.springframework.test.context.transaction.TransactionalTestExecutionLi
 @RunWith(SpringJUnit4ClassRunner.class)
 @TestExecutionListeners({ TransactionalTestExecutionListener.class, DependencyInjectionTestExecutionListener.class })
 @Category(CategorySubsystemTest.class)
-public abstract class SubsystemTest extends Assertions {
+public abstract class SubsystemTest extends BaseTest {
 
 }

--- a/modules/test/src/main/java/io/oasp/module/test/common/base/SystemTest.java
+++ b/modules/test/src/main/java/io/oasp/module/test/common/base/SystemTest.java
@@ -1,9 +1,8 @@
 package io.oasp.module.test.common.base;
 
-import io.oasp.module.test.common.api.category.CategorySystemTest;
-
-import org.assertj.core.api.Assertions;
 import org.junit.experimental.categories.Category;
+
+import io.oasp.module.test.common.api.category.CategorySystemTest;
 
 /**
  * This is the abstract base class for a system test. You are free to create your system tests as you like just by
@@ -14,6 +13,6 @@ import org.junit.experimental.categories.Category;
  *
  */
 @Category(CategorySystemTest.class)
-public abstract class SystemTest extends Assertions {
+public abstract class SystemTest extends BaseTest {
 
 }

--- a/modules/test/src/test/java/io/oasp/module/test/common/base/BaseTestTest.java
+++ b/modules/test/src/test/java/io/oasp/module/test/common/base/BaseTestTest.java
@@ -16,9 +16,9 @@ public class BaseTestTest extends Assertions {
   class MyTest extends BaseTest {
 
     @Override
-    protected void doSetUp(boolean initialized) {
+    protected void doSetUp() {
 
-      assertThat(initialized).isEqualTo(EXPECTED_RESULT);
+      assertThat(INITIALIZED).isEqualTo(EXPECTED_RESULT);
     }
   }
 

--- a/modules/test/src/test/java/io/oasp/module/test/common/base/BaseTestTest.java
+++ b/modules/test/src/test/java/io/oasp/module/test/common/base/BaseTestTest.java
@@ -1,0 +1,46 @@
+package io.oasp.module.test.common.base;
+
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * This test verifies the proper working of the {@link BaseTest} class.
+ *
+ * @author jmolinar
+ */
+public class BaseTestTest extends Assertions {
+
+  private static boolean EXPECTED_RESULT;
+
+  class MyTest extends BaseTest {
+
+    @Override
+    protected void doSetUp(boolean initialized) {
+
+      assertThat(initialized).isEqualTo(EXPECTED_RESULT);
+    }
+  }
+
+  @Test
+  public void testInitialization() {
+
+    BaseTest test = new MyTest();
+    // Set the expected result before running setUp()-
+    // Setup calls assertThat to test the expected result
+    EXPECTED_RESULT = false;
+    test.setUp();
+
+    EXPECTED_RESULT = true;
+    test.setUp();
+
+  }
+
+  @After
+  public void tearDown() {
+
+    // Just in case some test method will be added
+    MyTest.INITIALIZED = false;
+  }
+
+}

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/base/AbstractRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/base/AbstractRestServiceTest.java
@@ -3,8 +3,6 @@ package io.oasp.gastronomy.restaurant.general.common.base;
 import javax.inject.Inject;
 
 import org.flywaydb.core.Flyway;
-import org.junit.After;
-import org.junit.Before;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.WebIntegrationTest;
@@ -82,28 +80,12 @@ public abstract class AbstractRestServiceTest extends SubsystemTest {
   private JacksonJsonProvider jacksonJsonProvider;
 
   /**
-   * Calls {@link #doSetUp()}.
-   */
-  @Before
-  public final void setUp() {
-
-    doSetUp();
-  }
-
-  /**
-   * Calls {@link #doTearDown()}.
-   */
-  @After
-  public final void tearDown() {
-
-    doTearDown();
-  }
-
-  /**
    * Sets up the test.
    */
+  @Override
   protected void doSetUp() {
 
+    super.doSetUp();
     this.restTestClientBuilder.setLocalServerPort(this.port);
     this.restTestClientBuilder.setUser(this.user);
     this.restTestClientBuilder.setPassword(this.password);
@@ -118,9 +100,10 @@ public abstract class AbstractRestServiceTest extends SubsystemTest {
   /**
    * Cleans up the test.
    */
+  @Override
   protected void doTearDown() {
 
-    // empty implementation which may be overridden by a subclass.
+    super.doTearDown();
   }
 
   /**

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/base/AbstractRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/base/AbstractRestServiceTest.java
@@ -83,9 +83,9 @@ public abstract class AbstractRestServiceTest extends SubsystemTest {
    * Sets up the test.
    */
   @Override
-  protected void doSetUp() {
+  protected void doSetUp(boolean initialized) {
 
-    super.doSetUp();
+    super.doSetUp(initialized);
     this.restTestClientBuilder.setLocalServerPort(this.port);
     this.restTestClientBuilder.setUser(this.user);
     this.restTestClientBuilder.setPassword(this.password);

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/base/AbstractRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/base/AbstractRestServiceTest.java
@@ -83,9 +83,9 @@ public abstract class AbstractRestServiceTest extends SubsystemTest {
    * Sets up the test.
    */
   @Override
-  protected void doSetUp(boolean initialized) {
+  protected void doSetUp() {
 
-    super.doSetUp(initialized);
+    super.doSetUp();
     this.restTestClientBuilder.setLocalServerPort(this.port);
     this.restTestClientBuilder.setUser(this.user);
     this.restTestClientBuilder.setPassword(this.password);

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/OfferManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/OfferManagementTest.java
@@ -43,9 +43,9 @@ public class OfferManagementTest extends ComponentTest {
    * Login
    */
   @Override
-  public void doSetUp(boolean initialized) {
+  public void doSetUp() {
 
-    super.doSetUp(initialized);
+    super.doSetUp();
     this.flyway.clean();
     this.flyway.migrate();
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/OfferManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/OfferManagementTest.java
@@ -7,8 +7,6 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.flywaydb.core.Flyway;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -44,9 +42,10 @@ public class OfferManagementTest extends ComponentTest {
   /**
    * Login
    */
-  @Before
-  public void setUp() {
+  @Override
+  public void doSetUp() {
 
+    super.doSetUp();
     this.flyway.clean();
     this.flyway.migrate();
 
@@ -56,9 +55,10 @@ public class OfferManagementTest extends ComponentTest {
   /**
    * Logout
    */
-  @After
-  public void tearDown() {
+  @Override
+  public void doTearDown() {
 
+    super.doTearDown();
     TestUtil.logout();
   }
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/OfferManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/OfferManagementTest.java
@@ -43,9 +43,9 @@ public class OfferManagementTest extends ComponentTest {
    * Login
    */
   @Override
-  public void doSetUp() {
+  public void doSetUp(boolean initialized) {
 
-    super.doSetUp();
+    super.doSetUp(initialized);
     this.flyway.clean();
     this.flyway.migrate();
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
@@ -42,9 +42,9 @@ public class ProductManagementTest extends ComponentTest {
    * Login
    */
   @Override
-  public void doSetUp(boolean initialized) {
+  public void doSetUp() {
 
-    super.doSetUp(initialized);
+    super.doSetUp();
     this.flyway.clean();
     this.flyway.migrate();
     TestUtil.login("waiter", PermissionConstants.FIND_OFFER);

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
@@ -7,8 +7,6 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.flywaydb.core.Flyway;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -43,9 +41,10 @@ public class ProductManagementTest extends ComponentTest {
   /**
    * Login
    */
-  @Before
-  public void setUp() {
+  @Override
+  public void doSetUp() {
 
+    super.doSetUp();
     this.flyway.clean();
     this.flyway.migrate();
     TestUtil.login("waiter", PermissionConstants.FIND_OFFER);
@@ -54,9 +53,10 @@ public class ProductManagementTest extends ComponentTest {
   /**
    * Logout
    */
-  @After
-  public void tearDown() {
+  @Override
+  public void doTearDown() {
 
+    super.doTearDown();
     TestUtil.logout();
   }
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
@@ -42,9 +42,9 @@ public class ProductManagementTest extends ComponentTest {
    * Login
    */
   @Override
-  public void doSetUp() {
+  public void doSetUp(boolean initialized) {
 
-    super.doSetUp();
+    super.doSetUp(initialized);
     this.flyway.clean();
     this.flyway.migrate();
     TestUtil.login("waiter", PermissionConstants.FIND_OFFER);

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesManagementTest.java
@@ -4,8 +4,6 @@ import javax.inject.Inject;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -41,8 +39,8 @@ public class SalesManagementTest extends ComponentTest {
   /**
    * Initialization for the test.
    */
-  @Before
-  public void setUp() {
+  @Override
+  public void doSetUp() {
 
     TestUtil.login("waiter", PermissionConstants.FIND_ORDER_POSITION, PermissionConstants.SAVE_ORDER_POSITION,
         PermissionConstants.SAVE_ORDER, PermissionConstants.FIND_OFFER);
@@ -53,8 +51,8 @@ public class SalesManagementTest extends ComponentTest {
   /**
    * Log out utility for the test.
    */
-  @After
-  public void tearDown() {
+  @Override
+  public void doTearDown() {
 
     TestUtil.logout();
   }

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesManagementTest.java
@@ -40,9 +40,9 @@ public class SalesManagementTest extends ComponentTest {
    * Initialization for the test.
    */
   @Override
-  public void doSetUp(boolean initialized) {
+  public void doSetUp() {
 
-    super.doSetUp(initialized);
+    super.doSetUp();
     TestUtil.login("waiter", PermissionConstants.FIND_ORDER_POSITION, PermissionConstants.SAVE_ORDER_POSITION,
         PermissionConstants.SAVE_ORDER, PermissionConstants.FIND_OFFER);
     this.dbTestHelper.setMigrationVersion("0002");

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesManagementTest.java
@@ -40,8 +40,9 @@ public class SalesManagementTest extends ComponentTest {
    * Initialization for the test.
    */
   @Override
-  public void doSetUp() {
+  public void doSetUp(boolean initialized) {
 
+    super.doSetUp(initialized);
     TestUtil.login("waiter", PermissionConstants.FIND_ORDER_POSITION, PermissionConstants.SAVE_ORDER_POSITION,
         PermissionConstants.SAVE_ORDER, PermissionConstants.FIND_OFFER);
     this.dbTestHelper.setMigrationVersion("0002");

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementHttpRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementHttpRestServiceTest.java
@@ -24,8 +24,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -76,9 +74,10 @@ public class SalesmanagementHttpRestServiceTest extends AbstractRestServiceTest 
   /**
    * Provides initialization previous to the creation of the text fixture.
    */
-  @Before
-  public void init() {
+  @Override
+  public void doSetUp() {
 
+    super.doSetUp();
     getDbTestHelper().resetDatabase();
     this.service = getRestTestClientBuilder().build(SalesmanagementRestService.class);
   }
@@ -86,10 +85,11 @@ public class SalesmanagementHttpRestServiceTest extends AbstractRestServiceTest 
   /**
    * Provides clean up after tests.
    */
-  @After
-  public void clean() {
+  @Override
+  public void doTearDown() {
 
     this.service = null;
+    super.doTearDown();
   }
 
   /**

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceTest.java
@@ -15,12 +15,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -48,8 +44,6 @@ import io.oasp.module.jpa.common.api.to.PaginationTo;
 
 public class SalesmanagementRestServiceTest extends AbstractRestServiceTest {
 
-  private static Logger LOG = LoggerFactory.getLogger(SalesmanagementRestServiceTest.class);
-
   private SalesmanagementRestService service;
 
   @Inject
@@ -58,9 +52,10 @@ public class SalesmanagementRestServiceTest extends AbstractRestServiceTest {
   /**
    * Provides initialization previous to the creation of the text fixture.
    */
-  @Before
-  public void init() {
+  @Override
+  public void doSetUp() {
 
+    super.doSetUp();
     getDbTestHelper().resetDatabase();
     this.service = getRestTestClientBuilder().build(SalesmanagementRestService.class);
   }
@@ -68,10 +63,11 @@ public class SalesmanagementRestServiceTest extends AbstractRestServiceTest {
   /**
    * Provides clean up after tests.
    */
-  @After
-  public void clean() {
+  @Override
+  public void doTearDown() {
 
     this.service = null;
+    super.tearDown();
   }
 
   /**

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementImplTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementImplTest.java
@@ -51,9 +51,9 @@ public class TablemanagementImplTest extends ModuleTest {
    * Injection of the mocked objects into the SUT.
    */
   @Override
-  public void doSetUp(boolean initialized) {
+  public void doSetUp() {
 
-    super.doSetUp(initialized);
+    super.doSetUp();
     this.tableManagementImpl = new TablemanagementImpl();
     this.tableManagementImpl.setSalesmanagement(this.salesManagement);
     this.tableManagementImpl.setStaffmanagement(this.staffManagement);

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementImplTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementImplTest.java
@@ -51,9 +51,9 @@ public class TablemanagementImplTest extends ModuleTest {
    * Injection of the mocked objects into the SUT.
    */
   @Override
-  public void doSetUp() {
+  public void doSetUp(boolean initialized) {
 
-    super.doSetUp();
+    super.doSetUp(initialized);
     this.tableManagementImpl = new TablemanagementImpl();
     this.tableManagementImpl.setSalesmanagement(this.salesManagement);
     this.tableManagementImpl.setStaffmanagement(this.staffManagement);

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementImplTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementImplTest.java
@@ -3,8 +3,6 @@ package io.oasp.gastronomy.restaurant.tablemanagement.logic.impl;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -52,9 +50,10 @@ public class TablemanagementImplTest extends ModuleTest {
   /**
    * Injection of the mocked objects into the SUT.
    */
-  @Before
-  public void setup() {
+  @Override
+  public void doSetUp() {
 
+    super.doSetUp();
     this.tableManagementImpl = new TablemanagementImpl();
     this.tableManagementImpl.setSalesmanagement(this.salesManagement);
     this.tableManagementImpl.setStaffmanagement(this.staffManagement);
@@ -66,9 +65,10 @@ public class TablemanagementImplTest extends ModuleTest {
   /**
    * Delete the used mocks.
    */
-  @After
-  public void tearDown() {
+  @Override
+  public void doTearDown() {
 
+    super.doTearDown();
     this.salesManagement = null;
     this.staffManagement = null;
     this.beanMapper = null;

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementTest.java
@@ -50,9 +50,9 @@ public class TablemanagementTest extends ComponentTest {
    * to have a common basis for test.
    */
   @Override
-  public void doSetUp() {
+  public void doSetUp(boolean initialized) {
 
-    super.doSetUp();
+    super.doSetUp(initialized);
     TestUtil.login("waiter", PermissionConstants.SAVE_ORDER_POSITION, PermissionConstants.SAVE_ORDER,
         PermissionConstants.FIND_TABLE, PermissionConstants.FIND_ORDER, PermissionConstants.SAVE_TABLE,
         PermissionConstants.FIND_OFFER);

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementTest.java
@@ -50,9 +50,9 @@ public class TablemanagementTest extends ComponentTest {
    * to have a common basis for test.
    */
   @Override
-  public void doSetUp(boolean initialized) {
+  public void doSetUp() {
 
-    super.doSetUp(initialized);
+    super.doSetUp();
     TestUtil.login("waiter", PermissionConstants.SAVE_ORDER_POSITION, PermissionConstants.SAVE_ORDER,
         PermissionConstants.FIND_TABLE, PermissionConstants.FIND_ORDER, PermissionConstants.SAVE_TABLE,
         PermissionConstants.FIND_OFFER);

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementTest.java
@@ -6,8 +6,6 @@ import javax.inject.Inject;
 
 import net.sf.mmm.util.exception.api.ObjectNotFoundUserException;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.security.access.AccessDeniedException;
@@ -51,9 +49,10 @@ public class TablemanagementTest extends ComponentTest {
    * Provides login credentials and permissions and resets database. The database is migrated to Version 0002 in order
    * to have a common basis for test.
    */
-  @Before
-  public void setUp() {
+  @Override
+  public void doSetUp() {
 
+    super.doSetUp();
     TestUtil.login("waiter", PermissionConstants.SAVE_ORDER_POSITION, PermissionConstants.SAVE_ORDER,
         PermissionConstants.FIND_TABLE, PermissionConstants.FIND_ORDER, PermissionConstants.SAVE_TABLE,
         PermissionConstants.FIND_OFFER);
@@ -65,9 +64,10 @@ public class TablemanagementTest extends ComponentTest {
   /**
    * Logs out used credentials.
    */
-  @After
-  public void tearDown() {
+  @Override
+  public void doTearDown() {
 
+    super.doTearDown();
     TestUtil.logout();
   }
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceTest.java
@@ -2,8 +2,6 @@ package io.oasp.gastronomy.restaurant.tablemanagement.service.impl.rest;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.SpringApplicationConfiguration;
@@ -35,9 +33,10 @@ public class TablemanagementRestServiceTest extends AbstractRestServiceTest {
   /**
    * Provides initialization previous to the creation of the text fixture.
    */
-  @Before
-  public void init() {
+  @Override
+  public void doSetUp() {
 
+    super.doSetUp();
     getDbTestHelper().resetDatabase();
     this.service = getRestTestClientBuilder().build(TablemanagementRestService.class);
 
@@ -46,11 +45,11 @@ public class TablemanagementRestServiceTest extends AbstractRestServiceTest {
   /**
    * Provides clean up after tests.
    */
-  @After
-  public void clean() {
+  @Override
+  public void doTearDown() {
 
     this.service = null;
-
+    super.doTearDown();
   }
 
   /**


### PR DESCRIPTION
This PR is the first one of a sequence of PRs to cope with the complexity introduced in #474. 

This PR introduces `class BaseTest`, into the test class hierarchy. This introduction requires to change the base class of `ComponentTest, ModuleTest, SystemTest` and `SubsystemTest` to `BaseTest`.

The last commit in this PR solves compilation errors of concrete test implementations and adapts them to adhere to the assumptions stated in the JavaDoc of `BaseTest`.

To verify that tests are still work properly, `mvn clean install` has successfully been run.
