### PR TITLE
Fix JavaDoc generation

### DIFF
--- a/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/AbstractEto.java
+++ b/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/AbstractEto.java
@@ -11,7 +11,7 @@ import net.sf.mmm.util.transferobject.api.TransferObject;
  * {@link net.sf.mmm.util.lang.api.Datatype} and potentially for relations the ID (as {@link Long}). For actual
  * relations you will use {@link AbstractCto CTO}s to express what set of entities to transfer, load, save, update, etc.
  * without redundancies. It typically corresponds to an {@link net.sf.mmm.util.entity.api.GenericEntity entity}. For
- * additional details and an example consult the {@link net.sf.mmm.util.transferobject.api package JavaDoc}.
+ * additional details and an example consult the.
  *
  */
 public abstract class AbstractEto extends AbstractTo implements MutableRevisionedEntity<Long> {

--- a/modules/jpa-envers/src/main/java/io/oasp/module/jpa/dataaccess/base/AbstractGenericRevisionedDao.java
+++ b/modules/jpa-envers/src/main/java/io/oasp/module/jpa/dataaccess/base/AbstractGenericRevisionedDao.java
@@ -2,11 +2,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0 */
 package io.oasp.module.jpa.dataaccess.base;
 
-import io.oasp.module.jpa.dataaccess.api.GenericRevisionedDao;
-import io.oasp.module.jpa.dataaccess.api.RevisionMetadata;
-import io.oasp.module.jpa.dataaccess.api.MutablePersistenceEntity;
-import io.oasp.module.jpa.dataaccess.impl.LazyRevisionMetadata;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,17 +10,21 @@ import net.sf.mmm.util.exception.api.ObjectNotFoundException;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
 
+import io.oasp.module.jpa.dataaccess.api.GenericRevisionedDao;
+import io.oasp.module.jpa.dataaccess.api.MutablePersistenceEntity;
+import io.oasp.module.jpa.dataaccess.api.RevisionMetadata;
+import io.oasp.module.jpa.dataaccess.impl.LazyRevisionMetadata;
+
 /**
- * This is the abstract base-implementation of a {@link AbstractGenericDao} using {@link org.hibernate.envers
- * Hibernate-Envers} to manage the revision-control.
+ * This is the abstract base-implementation of a {@link AbstractGenericDao} using to manage the revision-control.
  *
  * @param <ID> is the type of the {@link MutablePersistenceEntity#getId() primary key} of the managed
  *        {@link MutablePersistenceEntity entity}.
  * @param <ENTITY> is the {@link #getEntityClass() type} of the managed entity.
  *
  */
-public abstract class AbstractGenericRevisionedDao<ID, ENTITY extends MutablePersistenceEntity<ID>> extends
-    AbstractGenericDao<ID, ENTITY> implements GenericRevisionedDao<ID, ENTITY> {
+public abstract class AbstractGenericRevisionedDao<ID, ENTITY extends MutablePersistenceEntity<ID>>
+    extends AbstractGenericDao<ID, ENTITY> implements GenericRevisionedDao<ID, ENTITY> {
 
   /**
    * The constructor.

--- a/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/SearchCriteriaTo.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/SearchCriteriaTo.java
@@ -21,7 +21,7 @@ public class SearchCriteriaTo extends AbstractTo {
   /** @see #getPagination() */
   private PaginationTo pagination;
 
-  /** @see #getSearchTimeout */
+  /** @see #getSearchTimeout() */
   private Integer searchTimeout;
 
   /** @see #getSort() */

--- a/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/SearchCriteriaTo.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/SearchCriteriaTo.java
@@ -1,8 +1,8 @@
 package io.oasp.module.jpa.common.api.to;
 
-import io.oasp.module.basic.common.api.to.AbstractTo;
-
 import java.util.List;
+
+import io.oasp.module.basic.common.api.to.AbstractTo;
 
 /**
  * This is the interface for a {@link net.sf.mmm.util.transferobject.api.TransferObject transfer-object } with the
@@ -21,7 +21,7 @@ public class SearchCriteriaTo extends AbstractTo {
   /** @see #getPagination() */
   private PaginationTo pagination;
 
-  /** @see getSearchTimeout */
+  /** @see #getSearchTimeout */
   private Integer searchTimeout;
 
   /** @see #getSort() */

--- a/modules/jpa/src/main/java/io/oasp/module/jpa/dataaccess/base/AbstractGenericDao.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/dataaccess/base/AbstractGenericDao.java
@@ -1,11 +1,5 @@
 package io.oasp.module.jpa.dataaccess.base;
 
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
-import io.oasp.module.jpa.common.api.to.PaginationResultTo;
-import io.oasp.module.jpa.common.api.to.PaginationTo;
-import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
-import io.oasp.module.jpa.dataaccess.api.GenericDao;
-
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -27,6 +21,12 @@ import org.slf4j.LoggerFactory;
 
 import com.mysema.query.jpa.impl.JPAQuery;
 import com.mysema.query.types.Expression;
+
+import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.jpa.common.api.to.PaginationResultTo;
+import io.oasp.module.jpa.common.api.to.PaginationTo;
+import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+import io.oasp.module.jpa.dataaccess.api.GenericDao;
 
 /**
  * This is the abstract base-implementation of the {@link GenericDao} interface.
@@ -216,7 +216,7 @@ public abstract class AbstractGenericDao<ID, E extends PersistenceEntity<ID>> im
   /**
    * Returns a paginated list of entities according to the supplied {@link SearchCriteriaTo criteria}.
    * <p>
-   * Applies {@code limit} and {@code offset} values to the supplied {@query} according to the supplied
+   * Applies {@code limit} and {@code offset} values to the supplied {@code query} according to the supplied
    * {@link PaginationTo pagination} information inside {@code criteria}.
    * <p>
    * If a {@link PaginationTo#isTotal() total count} of available entities is requested, will also execute a second

--- a/modules/security/src/main/java/io/oasp/module/security/common/api/accesscontrol/AccessControl.java
+++ b/modules/security/src/main/java/io/oasp/module/security/common/api/accesscontrol/AccessControl.java
@@ -23,7 +23,7 @@ public abstract class AccessControl implements Serializable {
   /** UID for serialization. */
   private static final long serialVersionUID = 1L;
 
-  /** @see #getName() */
+  /** @see #getId() */
   @XmlID
   @XmlAttribute(name = "id", required = true)
   @XmlJavaTypeAdapter(CollapsedStringAdapter.class)

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <!-- oasp4j-sample should actually be restaurant -->
     <servicedoc.basePath>oasp4j-sample/services/rest</servicedoc.basePath>
     <servicedocgen.version>1.0.0-beta-3</servicedocgen.version>
+    <javadoc.params></javadoc.params>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,15 @@
     <servicedoc.port>80</servicedoc.port>
     <!-- oasp4j-sample should actually be restaurant -->
     <servicedoc.basePath>oasp4j-sample/services/rest</servicedoc.basePath>
-    <servicedocgen.version>1.0.0-beta-3</servicedocgen.version>    
+    <servicedocgen.version>1.0.0-beta-3</servicedocgen.version>
   </properties>
-
+  <dependencies>
+    <dependency>
+      <groupId>javax.interceptor</groupId>
+      <artifactId>javax.interceptor-api</artifactId>
+      <version>1.2</version>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
@@ -145,9 +151,9 @@
           <version>2.7</version>
         </plugin>
         <plugin>
-           <groupId>org.apache.maven.plugins</groupId>
-           <artifactId>maven-compiler-plugin</artifactId>
-           <version>3.2</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -205,7 +211,7 @@
           <version>2.9.1</version>
           <configuration>
             <!-- http://jira.codehaus.org/browse/MJAVADOC-308 -->
-            <!--<maxmemory>5048m</maxmemory>-->
+            <!--<maxmemory>5048m</maxmemory> -->
             <notree>true</notree>
             <show>private</show>
             <encoding>${project.reporting.outputEncoding}</encoding>
@@ -315,7 +321,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <!--<notree>true</notree>-->
+          <!--<notree>true</notree> -->
           <show>private</show>
           <encoding>${project.reporting.outputEncoding}</encoding>
           <charset>${project.build.sourceEncoding}</charset>
@@ -324,7 +330,7 @@
           <additionalparam>-Xdoclint:none</additionalparam>
           <links>
             <link>http://docs.oracle.com/javase/7/docs/api/</link>
-            <!--<link>http://oasp.github.io/oasp4j/maven/apidocs/</link>-->
+            <!--<link>http://oasp.github.io/oasp4j/maven/apidocs/</link> -->
           </links>
           <doctitle>JavaDocs for ${project.name}</doctitle>
           <windowtitle>JavaDocs for ${project.name}</windowtitle>
@@ -349,7 +355,7 @@
         <reportSets>
           <reportSet>
             <reports>
-              <!-- https://github.com/jeremylong/DependencyCheck/issues/386-->
+              <!-- https://github.com/jeremylong/DependencyCheck/issues/386 -->
               <!-- <report>aggregate</report> -->
               <report>check</report>
             </reports>
@@ -437,7 +443,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <configuration>
-            	<keyname>${oasp.gpg.keyname}</keyname>
+              <keyname>${oasp.gpg.keyname}</keyname>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -35,13 +35,7 @@
     <servicedoc.basePath>oasp4j-sample/services/rest</servicedoc.basePath>
     <servicedocgen.version>1.0.0-beta-3</servicedocgen.version>
   </properties>
-  <dependencies>
-    <dependency>
-      <groupId>javax.interceptor</groupId>
-      <artifactId>javax.interceptor-api</artifactId>
-      <version>1.2</version>
-    </dependency>
-  </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -217,7 +211,7 @@
             <encoding>${project.reporting.outputEncoding}</encoding>
             <charset>${project.build.sourceEncoding}</charset>
             <docfilessubdirs>true</docfilessubdirs>
-            <additionalparam>-Xdoclint:none</additionalparam>
+            <additionalparam>${javadoc.params}</additionalparam>
             <links>
               <link>http://docs.oracle.com/javase/7/docs/api/</link>
               <link>http://m-m-m.sourceforge.net/apidocs/</link>
@@ -327,7 +321,7 @@
           <charset>${project.build.sourceEncoding}</charset>
           <docfilessubdirs>true</docfilessubdirs>
           <stylesheetfile>${user.dir}/src/main/javadoc/stylesheet.css</stylesheetfile>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <additionalparam>${javadoc.params}</additionalparam>
           <links>
             <link>http://docs.oracle.com/javase/7/docs/api/</link>
             <!--<link>http://oasp.github.io/oasp4j/maven/apidocs/</link> -->
@@ -389,6 +383,15 @@
   </reporting>
 
   <profiles>
+    <profile>
+      <id>doclint-disabled</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.params>-Xdoclint:none</javadoc.params>
+      </properties>
+    </profile>
     <profile>
       <id>all</id>
       <activation>

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/common/api/datatype/ProductSortByHitEntry.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/common/api/datatype/ProductSortByHitEntry.java
@@ -17,8 +17,9 @@ public enum ProductSortByHitEntry {
   DESCRIPTION("description"),
 
   /**
-   * Sort by {@link javax.persistence.DiscriminatorValue} (
-   * {@link io.oasp.gastronomy.restaurant.offermanagement.common.api.Product#getClass()}).
+   * Sort by {@link javax.persistence.DiscriminatorValue}
+   *
+   * @see Object#getClass()
    */
   DTYPE("dtype");
 

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/dataaccess/api/BillEntity.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/dataaccess/api/BillEntity.java
@@ -15,10 +15,11 @@ import javax.persistence.Transient;
 import io.oasp.gastronomy.restaurant.general.common.api.datatype.Money;
 import io.oasp.gastronomy.restaurant.general.dataaccess.api.ApplicationPersistenceEntity;
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.Bill;
+import io.oasp.gastronomy.restaurant.salesmanagement.common.api.OrderPosition;
 
 /**
  * {@link ApplicationPersistenceEntity Entity} that represents the {@link Bill} related to one or multiple
- * {@OrderPosition order positions}.
+ * {@link OrderPosition order positions}.
  *
  */
 @Entity

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/usecase/UcManageBillImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/usecase/UcManageBillImpl.java
@@ -1,5 +1,16 @@
 package io.oasp.gastronomy.restaurant.salesmanagement.logic.impl.usecase;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.oasp.gastronomy.restaurant.general.common.api.constants.PermissionConstants;
 import io.oasp.gastronomy.restaurant.general.common.api.datatype.Money;
 import io.oasp.gastronomy.restaurant.general.common.api.exception.IllegalEntityStateException;
@@ -18,17 +29,6 @@ import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcManageB
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.base.usecase.AbstractBillUc;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.impl.paymentadapter.PaymentAdapter;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.impl.paymentadapter.PaymentTransactionData;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
-import javax.annotation.security.RolesAllowed;
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of {@link UcManageBill}.
@@ -96,7 +96,7 @@ public class UcManageBillImpl extends AbstractBillUc implements UcManageBill {
   /**
    * This method updates a {@link BillEntity} by checking the existence of a bill with that {@link BillEntity#getId()
    * id} in the database. If no such {@link BillEntity} exists, a new bill will be created by calling
-   * {@link UcManageBillImpl#create(List, Money)}. Otherwise, the existing {@link BillEntity} will be updated by
+   * {@link UcManageBillImpl#createBill(BillEto)}. Otherwise, the existing {@link BillEntity} will be updated by
    * overriding the set {@link BillEntity#getOrderPositions() order positions}, {@link BillEntity#getTip() tip} and the
    * {@link BillEntity#getTotal() total amount}.
    *

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/usecase/UcManageOrderPositionImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/usecase/UcManageOrderPositionImpl.java
@@ -183,8 +183,8 @@ public class UcManageOrderPositionImpl extends AbstractOrderPositionUc implement
   }
 
   /**
-   * Verifies if an update of the {@link DrinkState} is legal. This verification is based on both the states of
-   * {@link DrinkState} and {@link OrderPositionState}.
+   * Verifies if an update of the {@link ProductOrderState} is legal. This verification is based on both the states of
+   * {@link ProductOrderState} and {@link OrderPositionState}.
    *
    * @param updateOrderPosition the new {@link OrderPosition} to update to.
    * @param currentState the old/current {@link OrderPositionState} of the {@link OrderPosition}.

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
@@ -18,6 +18,7 @@ import io.oasp.gastronomy.restaurant.general.common.TestUtil;
 import io.oasp.gastronomy.restaurant.general.common.api.constants.PermissionConstants;
 import io.oasp.gastronomy.restaurant.offermanagement.common.api.Product;
 import io.oasp.gastronomy.restaurant.offermanagement.common.api.datatype.ProductSortByHitEntry;
+import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.impl.dao.ProductDaoImpl;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.Offermanagement;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
@@ -26,7 +27,7 @@ import io.oasp.module.jpa.common.api.to.OrderDirection;
 import io.oasp.module.test.common.base.ComponentTest;
 
 /**
- * This is the test case of {@ProductDaoImpl}
+ * This is the test case of {@link ProductDaoImpl}
  *
  * @since dev
  */


### PR DESCRIPTION
This PR fixes the following exception:

``` txt
[ERROR] Exit code: 1 - javadoc: error - com.sun.tools.doclets.internal.toolkit.util.DocletAbortException: com.sun.tools.javac.code.Symbol$CompletionFailure: class file for javax.interceptor.InterceptorBinding not found
```

by adding 

``` xml
  <dependencies>
    <dependency>
      <groupId>javax.interceptor</groupId>
      <artifactId>javax.interceptor-api</artifactId>
      <version>1.2</version>
    </dependency>
  </dependencies>
```

to the `pom.xml` of oasp4j.
Now, running `mvn site` followed by `mvn site:stage` results in proper creation of JavaDoc.
The `site:stage` links JavaDoc sites locally, and therefore alllows to test the JavaDoc generation locally.

However, this PR is a first draft and definitely needs a review since I'm not sure whether this is a good solution.
