### PR TITLE
Removed @RunWith from alls subclasses of AbstractRestServiceTest

### DIFF
--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/api/security/SecurityRestServiceImplTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/api/security/SecurityRestServiceImplTest.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +16,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.client.RestTemplate;
 
 import io.oasp.gastronomy.restaurant.SpringBootApp;
@@ -28,7 +26,6 @@ import io.oasp.gastronomy.restaurant.general.service.impl.rest.SecurityRestServi
 /**
  * This class tests the login functionality of {@link SecurityRestServiceImpl}.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = SpringBootApp.class)
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
 public class SecurityRestServiceImplTest extends AbstractRestServiceTest {

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementHttpRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementHttpRestServiceTest.java
@@ -25,7 +25,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.http.HttpEntity;
@@ -34,7 +33,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.client.RestTemplate;
 
 import io.oasp.gastronomy.restaurant.SpringBootApp;
@@ -51,10 +49,8 @@ import io.oasp.gastronomy.restaurant.salesmanagement.service.api.rest.Salesmanag
  * database is accessed via HTTP requests to the server running the restaurant application.
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = { SpringBootApp.class, SalesmanagementRestTestConfig.class })
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
-
 public class SalesmanagementHttpRestServiceTest extends AbstractRestServiceTest {
 
   private final HttpHeaders AUTHENTIFICATED_HEADERS = getAuthentificatedHeaders();

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceTest.java
@@ -16,10 +16,8 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import io.oasp.gastronomy.restaurant.SpringBootApp;
 import io.oasp.gastronomy.restaurant.general.common.base.AbstractRestServiceTest;
@@ -38,10 +36,8 @@ import io.oasp.module.jpa.common.api.to.PaginationTo;
  * database is accessed via an instance of the class {@link SalesmanagementRestService}.
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = { SpringBootApp.class, SalesmanagementRestTestConfig.class })
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
-
 public class SalesmanagementRestServiceTest extends AbstractRestServiceTest {
 
   private SalesmanagementRestService service;

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceTest.java
@@ -3,10 +3,8 @@ package io.oasp.gastronomy.restaurant.tablemanagement.service.impl.rest;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import io.oasp.gastronomy.restaurant.SpringBootApp;
 import io.oasp.gastronomy.restaurant.general.common.api.builders.TableEtoBuilder;
@@ -21,11 +19,8 @@ import io.oasp.module.jpa.common.api.to.PaginatedListTo;
  * This class serves as an example of how to perform a subsystem test (e.g., call a *RestService interface).
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = SpringBootApp.class)
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
-// , locations = {"file:src/test/resources/config" })
-
 public class TablemanagementRestServiceTest extends AbstractRestServiceTest {
 
   private TablemanagementRestService service;


### PR DESCRIPTION
The classes `ComponentTest` and `SubsystemTest` are annotated with `@RunWith(SpringJUnit4ClassRunner.class)`. Therefore, this annotation is not needed in any subclasses which extend either of these classes.

This PR removes the `@RunWith` annotation where necessary.