### PR TITLE
Rename abstract rest service test

### DIFF
--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/api/security/SecurityRestServiceImplTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/api/security/SecurityRestServiceImplTest.java
@@ -22,7 +22,7 @@ import org.springframework.web.client.RestTemplate;
 
 import io.oasp.gastronomy.restaurant.SpringBootApp;
 import io.oasp.gastronomy.restaurant.general.common.api.to.UserDetailsClientTo;
-import io.oasp.gastronomy.restaurant.general.common.base.AbstractRestServiceTest;
+import io.oasp.gastronomy.restaurant.general.common.base.RestServiceTest;
 import io.oasp.gastronomy.restaurant.general.service.impl.rest.SecurityRestServiceImpl;
 
 /**
@@ -31,7 +31,7 @@ import io.oasp.gastronomy.restaurant.general.service.impl.rest.SecurityRestServi
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = SpringBootApp.class)
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
-public class SecurityRestServiceImplTest extends AbstractRestServiceTest {
+public class SecurityRestServiceImplTest extends RestServiceTest {
 
   /** Logger instance. */
   private static final Logger LOG = LoggerFactory.getLogger(SecurityRestServiceImplTest.class);

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/base/RestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/common/base/RestServiceTest.java
@@ -25,7 +25,7 @@ import io.oasp.module.test.common.base.SubsystemTest;
 @SpringApplicationConfiguration(classes = RestaurantTestConfig.class)
 @WebIntegrationTest
 @ActiveProfiles(profiles = { SpringProfileConstants.JUNIT })
-public abstract class AbstractRestServiceTest extends SubsystemTest {
+public abstract class RestServiceTest extends SubsystemTest {
 
   /**
    * The port of the web server during the test.

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/service/impl/config/RestaurantTestConfig.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/general/service/impl/config/RestaurantTestConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Profile;
 import io.oasp.gastronomy.restaurant.general.common.DbTestHelper;
 import io.oasp.gastronomy.restaurant.general.common.RestTestClientBuilder;
 import io.oasp.gastronomy.restaurant.general.common.SecurityTestHelper;
-import io.oasp.gastronomy.restaurant.general.common.base.AbstractRestServiceTest;
+import io.oasp.gastronomy.restaurant.general.common.base.RestServiceTest;
 import io.oasp.module.basic.common.api.config.SpringProfileConstants;
 
 /**
@@ -16,7 +16,7 @@ import io.oasp.module.basic.common.api.config.SpringProfileConstants;
  * following class annotation: {@code @SpringApplicationConfiguration(classes = RestaurantTestConfig.class)}. Hence,
  * beans provided by {@code @Bean} annotated methods will not be available outside the test configuration. <br/>
  * <br/>
- * See {@link AbstractRestServiceTest} as an example.
+ * See {@link RestServiceTest} as an example.
  *
  */
 @Configuration

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementHttpRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementHttpRestServiceTest.java
@@ -39,7 +39,7 @@ import org.springframework.web.client.RestTemplate;
 
 import io.oasp.gastronomy.restaurant.SpringBootApp;
 import io.oasp.gastronomy.restaurant.general.common.api.builders.OrderPositionEtoBuilder;
-import io.oasp.gastronomy.restaurant.general.common.base.AbstractRestServiceTest;
+import io.oasp.gastronomy.restaurant.general.common.base.RestServiceTest;
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.OrderPosition;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderCto;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderEto;
@@ -55,7 +55,7 @@ import io.oasp.gastronomy.restaurant.salesmanagement.service.api.rest.Salesmanag
 @SpringApplicationConfiguration(classes = { SpringBootApp.class, SalesmanagementRestTestConfig.class })
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
 
-public class SalesmanagementHttpRestServiceTest extends AbstractRestServiceTest {
+public class SalesmanagementHttpRestServiceTest extends RestServiceTest {
 
   private final HttpHeaders AUTHENTIFICATED_HEADERS = getAuthentificatedHeaders();
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import io.oasp.gastronomy.restaurant.SpringBootApp;
-import io.oasp.gastronomy.restaurant.general.common.base.AbstractRestServiceTest;
+import io.oasp.gastronomy.restaurant.general.common.base.RestServiceTest;
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.datatype.OrderPositionState;
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.datatype.OrderState;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderCto;
@@ -42,7 +42,7 @@ import io.oasp.module.jpa.common.api.to.PaginationTo;
 @SpringApplicationConfiguration(classes = { SpringBootApp.class, SalesmanagementRestTestConfig.class })
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
 
-public class SalesmanagementRestServiceTest extends AbstractRestServiceTest {
+public class SalesmanagementRestServiceTest extends RestServiceTest {
 
   private SalesmanagementRestService service;
 

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceTest.java
@@ -10,7 +10,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import io.oasp.gastronomy.restaurant.SpringBootApp;
 import io.oasp.gastronomy.restaurant.general.common.api.builders.TableEtoBuilder;
-import io.oasp.gastronomy.restaurant.general.common.base.AbstractRestServiceTest;
+import io.oasp.gastronomy.restaurant.general.common.base.RestServiceTest;
 import io.oasp.gastronomy.restaurant.tablemanagement.common.api.datatype.TableState;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableEto;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableSearchCriteriaTo;
@@ -26,7 +26,7 @@ import io.oasp.module.jpa.common.api.to.PaginatedListTo;
 @TestPropertySource(properties = { "flyway.locations=filesystem:src/test/resources/db/tablemanagement" })
 // , locations = {"file:src/test/resources/config" })
 
-public class TablemanagementRestServiceTest extends AbstractRestServiceTest {
+public class TablemanagementRestServiceTest extends RestServiceTest {
 
   private TablemanagementRestService service;
 
@@ -53,7 +53,7 @@ public class TablemanagementRestServiceTest extends AbstractRestServiceTest {
   }
 
   /**
-   * This test method serves as an example of how to use {@link AbstractRestServiceTest} in practice.
+   * This test method serves as an example of how to use {@link RestServiceTest} in practice.
    */
   @Test
   public void testFindTable() {


### PR DESCRIPTION
This PR renames the `AbstractRestServiceTest` base class to `RestServiceTest`. This reduces removes redundant information since the class declaration already tells the reader that  the class is `abstract`:
```java
public abstract class RestServiceTest extends SubsystemTest
```