### PR TITLE
Fix for 404 error received when clicked on the link '1. Table' in index.html that is displayed after logging into the sample application created from maven archeType

### DIFF
--- a/templates/server/src/main/resources/archetype-resources/core/src/main/resources/static/index.html
+++ b/templates/server/src/main/resources/archetype-resources/core/src/main/resources/static/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome</title>
+</head>
+<body>
+	<h3>Welcome</h3>
+	This is a test!
+	<br/>
+	<a href="services/">Services Overview (CXF)</a>
+  <br/>
+  <br/>
+
+  <form method="POST" action="logout">
+    <button>logout</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
Fix for the 404 error received when clicked on the link '1. Table' in index.html that is displayed after logging into the sample application created from maven archeType. 

Test case : 

1. Create sample application from maven archeType . Sample Command as follows : 

mvn -DarchetypeVersion=2.3.0-SNAPSHOT -DarchetypeGroupId=io.oasp.java.templates -DarchetypeArtifactId=oasp4j-template-server archetype:generate -DgroupId=io.oasp.application -DartifactId=fixArcheTypeIssue -Dversion=0.1-SNAPSHOT -Dpackage=io.oasp.application.fixArcheTypeIssue

2. Launch SpringBootApp inside the sample application and hit the url http://localhost:8081/oasp4j-sample-server and login using the credentials of waiter . 

3. In the page (index.html) displayed , see that the link for '1. Table' is not displayed. 

Thanks,
@kiran-vadla