### PR TITLE
Removed hohwille gpg config

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <cxf.version>3.1.8</cxf.version>
     <mmm.util.version>7.3.0</mmm.util.version>
-    <oasp.gpg.keyname>joerg.hohwiller@capgemini.com</oasp.gpg.keyname>
     <oasp.flatten.mode>bom</oasp.flatten.mode>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <oasp4j.version>2.4.0-SNAPSHOT</oasp4j.version>
     <port.range>81</port.range>
-    <oasp.gpg.keyname>joerg.hohwiller@capgemini.com</oasp.gpg.keyname>
     <oasp.flatten.mode>oss</oasp.flatten.mode>
     <spring.boot.version>1.3.8.RELEASE</spring.boot.version>
     <js.client.dir>src/main/client</js.client.dir>


### PR DESCRIPTION
For historical reasons, there was the gpg config of hohwille in the pom files. I removed it and updated the release process description accoringly.