### PR TITLE
moved pagination TOs to basic module as they are not JPA specific

### DIFF
--- a/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/OrderByTo.java
+++ b/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/OrderByTo.java
@@ -1,6 +1,4 @@
-package io.oasp.module.jpa.common.api.to;
-
-import io.oasp.module.basic.common.api.to.AbstractTo;
+package io.oasp.module.basic.common.api.to;
 
 /**
  * Transfer object to transmit order criteria

--- a/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/OrderDirection.java
+++ b/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/OrderDirection.java
@@ -1,4 +1,4 @@
-package io.oasp.module.jpa.common.api.to;
+package io.oasp.module.basic.common.api.to;
 
 /**
  * {@link Enum} for sort order.

--- a/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/PaginatedListTo.java
+++ b/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/PaginatedListTo.java
@@ -1,11 +1,9 @@
-package io.oasp.module.jpa.common.api.to;
+package io.oasp.module.basic.common.api.to;
 
 import java.util.List;
 
 import net.sf.mmm.util.entity.api.PersistenceEntity;
 import net.sf.mmm.util.transferobject.api.TransferObject;
-
-import io.oasp.module.basic.common.api.to.AbstractTo;
 
 /**
  * A paginated list of objects with additional pagination information.

--- a/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/PaginationResultTo.java
+++ b/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/PaginationResultTo.java
@@ -1,8 +1,6 @@
-package io.oasp.module.jpa.common.api.to;
+package io.oasp.module.basic.common.api.to;
 
 import net.sf.mmm.util.exception.api.NlsIllegalArgumentException;
-
-import io.oasp.module.basic.common.api.to.AbstractTo;
 
 /**
  * Pagination information about a paginated query.

--- a/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/PaginationTo.java
+++ b/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/PaginationTo.java
@@ -1,6 +1,4 @@
-package io.oasp.module.jpa.common.api.to;
-
-import io.oasp.module.basic.common.api.to.AbstractTo;
+package io.oasp.module.basic.common.api.to;
 
 import net.sf.mmm.util.exception.api.NlsIllegalArgumentException;
 

--- a/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/SearchCriteriaTo.java
+++ b/modules/basic/src/main/java/io/oasp/module/basic/common/api/to/SearchCriteriaTo.java
@@ -1,8 +1,6 @@
-package io.oasp.module.jpa.common.api.to;
+package io.oasp.module.basic.common.api.to;
 
 import java.util.List;
-
-import io.oasp.module.basic.common.api.to.AbstractTo;
 
 /**
  * This is the interface for a {@link net.sf.mmm.util.transferobject.api.TransferObject transfer-object } with the

--- a/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/OrderByTo.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/OrderByTo.java
@@ -1,0 +1,76 @@
+package io.oasp.module.jpa.common.api.to;
+
+import io.oasp.module.basic.common.api.to.AbstractTo;
+
+/**
+ * Transfer object to transmit order criteria.
+ *
+ * @deprecated has been moved to {@link io.oasp.module.basic.common.api.to.OrderByTo oasp-basic module}. Please use the
+ *             new implementation in favor of this unsupported one.
+ */
+@Deprecated
+public class OrderByTo extends AbstractTo {
+
+  private static final long serialVersionUID = 1L;
+
+  private String name;
+
+  private OrderDirection direction;
+
+  /**
+   * The constructor.
+   */
+  public OrderByTo() {
+
+    super();
+  }
+
+  /**
+   * Returns the field 'name'.
+   *
+   * @return Value of name
+   */
+  public String getName() {
+
+    return this.name;
+  }
+
+  /**
+   * Sets the field 'name'.
+   *
+   * @param name New value for name
+   */
+  public void setName(String name) {
+
+    this.name = name;
+  }
+
+  /**
+   * Returns the field 'direction'.
+   *
+   * @return Value of direction
+   */
+  public OrderDirection getDirection() {
+
+    return this.direction;
+  }
+
+  /**
+   * Sets the field 'direction'.
+   *
+   * @param direction New value for direction
+   */
+  public void setDirection(OrderDirection direction) {
+
+    this.direction = direction;
+  }
+
+  @Override
+  protected void toString(StringBuilder buffer) {
+
+    buffer.append(this.name);
+    buffer.append(' ');
+    buffer.append(this.direction);
+  }
+
+}

--- a/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/OrderDirection.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/OrderDirection.java
@@ -1,0 +1,34 @@
+package io.oasp.module.jpa.common.api.to;
+
+/**
+ * {@link Enum} for sort order.
+ *
+ * @deprecated has been moved to {@link io.oasp.module.basic.common.api.to.OrderDirection oasp-basic module}. Please use
+ *             the new implementation in favor of this unsupported one.
+ */
+@Deprecated
+public enum OrderDirection {
+
+  /** Sort in ascending order. */
+  ASC,
+
+  /** Sort in descending order. */
+  DESC;
+
+  /**
+   * @return {@code true}, if {@link OrderDirection#ASC} is set. {@code false} otherwise.
+   */
+  public boolean isAsc() {
+
+    return this == ASC;
+  }
+
+  /**
+   * @return {@code true}, if {@link OrderDirection#DESC} is set. {@code false} otherwise.
+   */
+  public boolean isDesc() {
+
+    return this == DESC;
+  }
+
+}

--- a/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/PaginatedListTo.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/PaginatedListTo.java
@@ -1,0 +1,80 @@
+package io.oasp.module.jpa.common.api.to;
+
+import java.util.List;
+
+import net.sf.mmm.util.entity.api.PersistenceEntity;
+import net.sf.mmm.util.transferobject.api.TransferObject;
+
+import io.oasp.module.basic.common.api.to.AbstractTo;
+
+/**
+ * A paginated list of objects with additional pagination information.
+ *
+ * @param <E> is the generic type of the objects. Will usually be a {@link PersistenceEntity persistent entity} when
+ *        used in the data layer, or a {@link TransferObject transfer object}.
+ *
+ * @deprecated has been moved to {@link io.oasp.module.basic.common.api.to.PaginatedListTo oasp-basic module}. Please
+ *             use the new implementation in favor of this unsupported one.
+ */
+@Deprecated
+public class PaginatedListTo<E> extends AbstractTo {
+
+  /** UID for serialization. */
+  private static final long serialVersionUID = 1L;
+
+  /** @see #getPagination() */
+  private PaginationResultTo pagination;
+
+  /** @see #getResult() */
+  private List<E> result;
+
+  /**
+   * The constructor.
+   */
+  public PaginatedListTo() {
+    super();
+  }
+
+  /**
+   * A convenience constructor which accepts a paginated list and {@link PaginationResultTo pagination information}.
+   *
+   * @param result is the list of objects.
+   * @param pagination is the {@link PaginationResultTo pagination information}.
+   */
+  public PaginatedListTo(List<E> result, PaginationResultTo pagination) {
+
+    this.result = result;
+    this.pagination = pagination;
+  }
+
+  /**
+   * @return the list of objects.
+   */
+  public List<E> getResult() {
+
+    return this.result;
+  }
+
+  /**
+   * @return pagination is the {@link PaginationResultTo pagination information}.
+   */
+  public PaginationResultTo getPagination() {
+
+    return this.pagination;
+  }
+
+  @Override
+  protected void toString(StringBuilder buffer) {
+
+    super.toString(buffer);
+    buffer.append('@');
+    if (this.result != null) {
+      buffer.append("#result=");
+      buffer.append(this.result.size());
+    }
+    if (this.pagination != null) {
+      buffer.append(',');
+      this.pagination.toString(buffer);
+    }
+  }
+}

--- a/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/PaginationResultTo.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/PaginationResultTo.java
@@ -1,0 +1,117 @@
+package io.oasp.module.jpa.common.api.to;
+
+import net.sf.mmm.util.exception.api.NlsIllegalArgumentException;
+
+import io.oasp.module.basic.common.api.to.AbstractTo;
+
+/**
+ * Pagination information about a paginated query.
+ *
+ * @deprecated has been moved to {@link io.oasp.module.basic.common.api.to.PaginationResultTo oasp-basic module}. Please
+ *             use the new implementation in favor of this unsupported one.
+ */
+@Deprecated
+public class PaginationResultTo extends AbstractTo {
+
+  /** UID for serialization. */
+  private static final long serialVersionUID = 1L;
+
+  /** @see #getSize() */
+  private Integer size;
+
+  /** @see #getPage() */
+  private int page = 1;
+
+  /** @see #getTotal() */
+  private Long total;
+
+  /**
+   * The constructor.
+   */
+  public PaginationResultTo() {
+    super();
+  }
+
+  /**
+   * Constructor expecting an existing {@link PaginationTo pagination criteria} and the total number of results found.
+   *
+   * @param pagination is an existing {@link PaginationTo pagination criteria}.
+   * @param total is the total number of results found without pagination.
+   */
+  public PaginationResultTo(PaginationTo pagination, Long total) {
+
+    super();
+
+    setPage(pagination.getPage());
+    setSize(pagination.getSize());
+    setTotal(total);
+  }
+
+  /**
+   * @return size the size of a page.
+   */
+  public Integer getSize() {
+
+    return this.size;
+  }
+
+  /**
+   * @param size the size of a page.
+   */
+  public void setSize(Integer size) {
+
+    this.size = size;
+  }
+
+  /**
+   * @return page the current page.
+   */
+  public int getPage() {
+
+    return this.page;
+  }
+
+  /**
+   * @param page the current page. Must be greater than 0.
+   */
+  public void setPage(int page) {
+
+    if (page <= 0) {
+      throw new NlsIllegalArgumentException(page, "page");
+    }
+    this.page = page;
+  }
+
+  /**
+   * @return total the total number of entities
+   */
+  public Long getTotal() {
+
+    return this.total;
+  }
+
+  /**
+   * @param total the total number of entities
+   */
+  public void setTotal(Long total) {
+
+    this.total = total;
+  }
+
+  @Override
+  protected void toString(StringBuilder buffer) {
+
+    super.toString(buffer);
+    buffer.append("@page=");
+    buffer.append(this.page);
+    if (this.size != null) {
+      buffer.append(", size=");
+      buffer.append(this.size);
+    }
+    if (this.total != null) {
+      buffer.append(", total=");
+      buffer.append(this.total);
+    }
+  }
+
+}

--- a/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/PaginationTo.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/PaginationTo.java
@@ -1,0 +1,100 @@
+package io.oasp.module.jpa.common.api.to;
+
+import net.sf.mmm.util.exception.api.NlsIllegalArgumentException;
+
+import io.oasp.module.basic.common.api.to.AbstractTo;
+
+/**
+ * A {@link net.sf.mmm.util.transferobject.api.TransferObject transfer-object} containing criteria for paginating
+ * queries.
+ *
+ * @deprecated has been moved to {@link io.oasp.module.basic.common.api.to.PaginationTo oasp-basic module}. Please use
+ *             the new implementation in favor of this unsupported one.
+ */
+@Deprecated
+public class PaginationTo extends AbstractTo {
+
+  /**
+   * Empty {@link PaginationTo} indicating no pagination.
+   */
+  public static final PaginationTo NO_PAGINATION = new PaginationTo();
+
+  /** UID for serialization. */
+  private static final long serialVersionUID = 1L;
+
+  /** @see #getSize() */
+  private Integer size;
+
+  /** @see #getPage() */
+  private int page = 1;
+
+  /** @see #isTotal() */
+  private boolean total;
+
+  /**
+   * @return size the size of a page.
+   */
+  public Integer getSize() {
+
+    return this.size;
+  }
+
+  /**
+   * @param size the size of a page.
+   */
+  public void setSize(Integer size) {
+
+    this.size = size;
+  }
+
+  /**
+   * @return page the current page.
+   */
+  public int getPage() {
+
+    return this.page;
+  }
+
+  /**
+   * @param page the current page. Must be greater than 0.
+   */
+  public void setPage(int page) {
+
+    if (page <= 0) {
+      throw new NlsIllegalArgumentException(page, "page");
+    }
+    this.page = page;
+  }
+
+  /**
+   * @return total is {@code true} if the client requests that the server calculates the total number of entries found.
+   */
+  public boolean isTotal() {
+
+    return this.total;
+  }
+
+  /**
+   * @param total is {@code true} to request calculation of the total number of entries.
+   */
+  public void setTotal(boolean total) {
+
+    this.total = total;
+  }
+
+  @Override
+  protected void toString(StringBuilder buffer) {
+
+    super.toString(buffer);
+    buffer.append("@page=");
+    buffer.append(this.page);
+    if (this.size != null) {
+      buffer.append(", size=");
+      buffer.append(this.size);
+    }
+    if (this.total) {
+      buffer.append(", total");
+    }
+  }
+
+}

--- a/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/SearchCriteriaTo.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/common/api/to/SearchCriteriaTo.java
@@ -1,0 +1,116 @@
+package io.oasp.module.jpa.common.api.to;
+
+import java.util.List;
+
+import io.oasp.module.basic.common.api.to.AbstractTo;
+
+/**
+ * This is the interface for a {@link net.sf.mmm.util.transferobject.api.TransferObject transfer-object } with the
+ * criteria for a search and pagination query. Such object specifies the criteria selecting which hits will match when
+ * performing a search.<br/>
+ * <b>NOTE:</b><br/>
+ * This interface only holds the necessary settings for the pagination part of a query. For your individual search, you
+ * extend {@link SearchCriteriaTo} to create a java bean with all the fields for your search.
+ *
+ * @deprecated has been moved to {@link io.oasp.module.basic.common.api.to.SearchCriteriaTo oasp-basic module}. Please
+ *             use the new implementation in favor of this unsupported one.
+ */
+@Deprecated
+public class SearchCriteriaTo extends AbstractTo {
+
+  /** UID for serialization. */
+  private static final long serialVersionUID = 1L;
+
+  /** @see #getPagination() */
+  private PaginationTo pagination;
+
+  /** @see #getSearchTimeout() */
+  private Integer searchTimeout;
+
+  /** @see #getSort() */
+  private List<OrderByTo> sort;
+
+  /**
+   * The constructor.
+   */
+  public SearchCriteriaTo() {
+
+    super();
+  }
+
+  /**
+   * The currently active pagination.
+   *
+   * @return pagination the currently active pagination or {@link PaginationTo#NO_PAGINATION} if no specific pagination
+   *         has been set. Will never return {@code null}.
+   */
+  public PaginationTo getPagination() {
+
+    return this.pagination == null ? PaginationTo.NO_PAGINATION : this.pagination;
+  }
+
+  /**
+   * @param pagination the pagination to set
+   */
+  public void setPagination(PaginationTo pagination) {
+
+    this.pagination = pagination;
+  }
+
+  /**
+   * Limits the {@link PaginationTo#getSize() page size} by the given <code>limit</code>.
+   * <p>
+   * If currently no pagination is active, or the {@link PaginationTo#getSize() current page size} is {@code null} or
+   * greater than the given {@code limit}, the value is replaced by {@code limit}
+   *
+   * @param limit is the maximum allowed value for the {@link PaginationTo#getSize() page size}.
+   */
+  public void limitMaximumPageSize(int limit) {
+
+    if (getPagination() == PaginationTo.NO_PAGINATION) {
+      setPagination(new PaginationTo());
+    }
+
+    Integer pageSize = getPagination().getSize();
+    if ((pageSize == null) || (pageSize.intValue() > limit)) {
+      getPagination().setSize((Integer.valueOf(limit)));
+    }
+  }
+
+  /**
+   * This method gets the maximum delay in milliseconds the search may last until it is canceled. <br>
+   * <b>Note:</b><br>
+   * This feature is the same as the query hint <code>"javax.persistence.query.timeout"</code> in JPA.
+   *
+   * @return the search timeout in milliseconds or {@code null} for NO timeout.
+   */
+  public Integer getSearchTimeout() {
+
+    return this.searchTimeout;
+  }
+
+  /**
+   * @param searchTimeout is the new value of {@link #getSearchTimeout()}.
+   */
+  public void setSearchTimeout(int searchTimeout) {
+
+    this.searchTimeout = searchTimeout;
+  }
+
+  /**
+   * @return sort Sort criterias list
+   */
+  public List<OrderByTo> getSort() {
+
+    return this.sort;
+  }
+
+  /**
+   * @param sort Set the sort criterias list
+   */
+  public void setSort(List<OrderByTo> sort) {
+
+    this.sort = sort;
+  }
+
+}

--- a/modules/jpa/src/main/java/io/oasp/module/jpa/dataaccess/base/AbstractGenericDao.java
+++ b/modules/jpa/src/main/java/io/oasp/module/jpa/dataaccess/base/AbstractGenericDao.java
@@ -25,10 +25,10 @@ import org.slf4j.LoggerFactory;
 import com.mysema.query.jpa.impl.JPAQuery;
 import com.mysema.query.types.Expression;
 
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
-import io.oasp.module.jpa.common.api.to.PaginationResultTo;
-import io.oasp.module.jpa.common.api.to.PaginationTo;
-import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginationResultTo;
+import io.oasp.module.basic.common.api.to.PaginationTo;
+import io.oasp.module.basic.common.api.to.SearchCriteriaTo;
 import io.oasp.module.jpa.dataaccess.api.GenericDao;
 
 /**

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/logic/base/AbstractComponentFacade.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/logic/base/AbstractComponentFacade.java
@@ -2,7 +2,7 @@ package io.oasp.gastronomy.restaurant.general.logic.base;
 
 
 import io.oasp.gastronomy.restaurant.general.common.base.AbstractBeanMapperSupport;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/logic/base/AbstractUc.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/general/logic/base/AbstractUc.java
@@ -1,7 +1,7 @@
 package io.oasp.gastronomy.restaurant.general.logic.base;
 
 import io.oasp.gastronomy.restaurant.general.common.base.AbstractBeanMapperSupport;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/api/dao/OfferDao.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/api/dao/OfferDao.java
@@ -5,7 +5,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.OfferEntity;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferFilter;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 import io.oasp.module.jpa.dataaccess.api.MasterDataDao;
 
 import java.util.List;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/api/dao/ProductDao.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/api/dao/ProductDao.java
@@ -5,7 +5,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.ProductEntit
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 import io.oasp.module.jpa.dataaccess.api.MasterDataDao;
 
 import java.util.List;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/impl/dao/OfferDaoImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/impl/dao/OfferDaoImpl.java
@@ -13,7 +13,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.dao.OfferDao
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferFilter;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/impl/dao/ProductDaoImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/dataaccess/impl/dao/ProductDaoImpl.java
@@ -11,9 +11,9 @@ import io.oasp.gastronomy.restaurant.offermanagement.dataaccess.api.dao.ProductD
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
-import io.oasp.module.jpa.common.api.to.PaginationResultTo;
-import io.oasp.module.jpa.common.api.to.PaginationTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginationResultTo;
+import io.oasp.module.basic.common.api.to.PaginationTo;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/Offermanagement.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/Offermanagement.java
@@ -13,7 +13,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.SideDishEto;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.sql.Blob;
 import java.util.List;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/OfferSearchCriteriaTo.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/OfferSearchCriteriaTo.java
@@ -2,7 +2,7 @@ package io.oasp.gastronomy.restaurant.offermanagement.logic.api.to;
 
 import io.oasp.gastronomy.restaurant.general.common.api.datatype.Money;
 import io.oasp.gastronomy.restaurant.offermanagement.common.api.datatype.OfferState;
-import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+import io.oasp.module.basic.common.api.to.SearchCriteriaTo;
 
 /**
  * This is the {@link SearchCriteriaTo search criteria} {@link net.sf.mmm.util.transferobject.api.TransferObject TO}

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/OfferSortBy.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/OfferSortBy.java
@@ -1,7 +1,7 @@
 package io.oasp.gastronomy.restaurant.offermanagement.logic.api.to;
 
 import io.oasp.gastronomy.restaurant.offermanagement.common.api.datatype.OfferSortByHitEntry;
-import io.oasp.module.jpa.common.api.to.OrderDirection;
+import io.oasp.module.basic.common.api.to.OrderDirection;
 
 /**
  *

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/ProductSearchCriteriaTo.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/ProductSearchCriteriaTo.java
@@ -1,7 +1,7 @@
 package io.oasp.gastronomy.restaurant.offermanagement.logic.api.to;
 
 import io.oasp.gastronomy.restaurant.offermanagement.common.api.Product;
-import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+import io.oasp.module.basic.common.api.to.SearchCriteriaTo;
 
 /**
  * This is the {@link SearchCriteriaTo search criteria} {@link net.sf.mmm.util.transferobject.api.TransferObject TO}

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/ProductSortBy.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/api/to/ProductSortBy.java
@@ -1,7 +1,7 @@
 package io.oasp.gastronomy.restaurant.offermanagement.logic.api.to;
 
 import io.oasp.gastronomy.restaurant.offermanagement.common.api.datatype.ProductSortByHitEntry;
-import io.oasp.module.jpa.common.api.to.OrderDirection;
+import io.oasp.module.basic.common.api.to.OrderDirection;
 
 /**
  *

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/OffermanagementImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/logic/impl/OffermanagementImpl.java
@@ -27,7 +27,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.SideDishEto;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.sql.Blob;
 import java.util.ArrayList;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/service/api/rest/OffermanagementRestService.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/service/api/rest/OffermanagementRestService.java
@@ -35,7 +35,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchC
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.SideDishEto;
 import io.oasp.gastronomy.restaurant.offermanagement.service.impl.rest.OffermanagementRestServiceImpl;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 /**
  *

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/service/impl/rest/OffermanagementRestServiceImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/offermanagement/service/impl/rest/OffermanagementRestServiceImpl.java
@@ -33,7 +33,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSearchC
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.SideDishEto;
 import io.oasp.gastronomy.restaurant.offermanagement.service.api.rest.OffermanagementRestService;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 /**
  */

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/dataaccess/api/dao/OrderDao.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/dataaccess/api/dao/OrderDao.java
@@ -3,7 +3,7 @@ package io.oasp.gastronomy.restaurant.salesmanagement.dataaccess.api.dao;
 import io.oasp.gastronomy.restaurant.general.dataaccess.api.dao.ApplicationDao;
 import io.oasp.gastronomy.restaurant.salesmanagement.dataaccess.api.OrderEntity;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.List;
 

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/dataaccess/impl/dao/OrderDaoImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/dataaccess/impl/dao/OrderDaoImpl.java
@@ -7,7 +7,7 @@ import io.oasp.gastronomy.restaurant.salesmanagement.common.api.datatype.OrderSt
 import io.oasp.gastronomy.restaurant.salesmanagement.dataaccess.api.OrderEntity;
 import io.oasp.gastronomy.restaurant.salesmanagement.dataaccess.api.dao.OrderDao;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.List;
 

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/api/to/OrderPositionSearchCriteriaTo.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/api/to/OrderPositionSearchCriteriaTo.java
@@ -2,7 +2,7 @@ package io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to;
 
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.datatype.OrderPositionState;
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.datatype.ProductOrderState;
-import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+import io.oasp.module.basic.common.api.to.SearchCriteriaTo;
 
 /**
  * This is the {@link SearchCriteriaTo search criteria} {@link net.sf.mmm.util.transferobject.api.TransferObject TO}

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/api/to/OrderSearchCriteriaTo.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/api/to/OrderSearchCriteriaTo.java
@@ -1,7 +1,7 @@
 package io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to;
 
 import io.oasp.gastronomy.restaurant.salesmanagement.common.api.datatype.OrderState;
-import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+import io.oasp.module.basic.common.api.to.SearchCriteriaTo;
 
 /**
  * This is the {@link SearchCriteriaTo search criteria} {@link net.sf.mmm.util.transferobject.api.TransferObject TO}

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/api/usecase/UcFindOrder.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/api/usecase/UcFindOrder.java
@@ -3,7 +3,7 @@ package io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderCto;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderEto;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.List;
 

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesmanagementImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/SalesmanagementImpl.java
@@ -20,7 +20,7 @@ import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcFindOrd
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcManageBill;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcManageOrder;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcManageOrderPosition;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.List;
 

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/usecase/UcFindOrderImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/logic/impl/usecase/UcFindOrderImpl.java
@@ -10,7 +10,7 @@ import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderPositionE
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcFindOrder;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.base.usecase.AbstractOrderUc;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/service/api/rest/SalesmanagementRestService.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/service/api/rest/SalesmanagementRestService.java
@@ -32,7 +32,7 @@ import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcFindOrd
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcManageBill;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcManageOrder;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.usecase.UcManageOrderPosition;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 /**
  *

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceImpl.java
@@ -22,8 +22,8 @@ import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderPositionS
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.PaymentData;
 import io.oasp.gastronomy.restaurant.salesmanagement.service.api.rest.SalesmanagementRestService;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
-import io.oasp.module.jpa.common.api.to.PaginationTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginationTo;
 import io.oasp.module.rest.service.api.RequestParameters;
 
 /**

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/dataaccess/api/dao/StaffMemberDao.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/dataaccess/api/dao/StaffMemberDao.java
@@ -3,7 +3,7 @@ package io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.api.dao;
 import io.oasp.gastronomy.restaurant.general.dataaccess.api.dao.ApplicationDao;
 import io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.api.StaffMemberEntity;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 import io.oasp.module.jpa.dataaccess.api.MasterDataDao;
 
 /**

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/dataaccess/impl/dao/StaffMemberDaoImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/dataaccess/impl/dao/StaffMemberDaoImpl.java
@@ -7,7 +7,7 @@ import io.oasp.gastronomy.restaurant.general.dataaccess.base.dao.ApplicationMast
 import io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.api.StaffMemberEntity;
 import io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.api.dao.StaffMemberDao;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import javax.inject.Named;
 import javax.persistence.TypedQuery;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/api/Staffmanagement.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/api/Staffmanagement.java
@@ -2,7 +2,7 @@ package io.oasp.gastronomy.restaurant.staffmanagement.logic.api;
 
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberEto;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.List;
 

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/api/to/StaffMemberSearchCriteriaTo.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/api/to/StaffMemberSearchCriteriaTo.java
@@ -1,7 +1,7 @@
 package io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to;
 
 import io.oasp.gastronomy.restaurant.general.common.api.datatype.Role;
-import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+import io.oasp.module.basic.common.api.to.SearchCriteriaTo;
 
 /**
  * This is the {@link SearchCriteriaTo search criteria} {@link net.sf.mmm.util.transferobject.api.TransferObject TO}

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/impl/StaffmanagementImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/logic/impl/StaffmanagementImpl.java
@@ -22,7 +22,7 @@ import io.oasp.gastronomy.restaurant.staffmanagement.dataaccess.api.dao.StaffMem
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.Staffmanagement;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberEto;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 /**
  * Implementation of {@link Staffmanagement}.

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/service/api/rest/StaffmanagementRestService.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/service/api/rest/StaffmanagementRestService.java
@@ -16,7 +16,7 @@ import io.oasp.gastronomy.restaurant.general.common.api.RestService;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.Staffmanagement;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberEto;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 /**
  *

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/service/impl/rest/StaffmanagementRestServiceImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/staffmanagement/service/impl/rest/StaffmanagementRestServiceImpl.java
@@ -9,7 +9,7 @@ import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.Staffmanagement;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberEto;
 import io.oasp.gastronomy.restaurant.staffmanagement.logic.api.to.StaffMemberSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.staffmanagement.service.api.rest.StaffmanagementRestService;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 /**
  */

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/dataaccess/api/dao/TableDao.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/dataaccess/api/dao/TableDao.java
@@ -3,7 +3,7 @@ package io.oasp.gastronomy.restaurant.tablemanagement.dataaccess.api.dao;
 import io.oasp.gastronomy.restaurant.general.dataaccess.api.dao.ApplicationDao;
 import io.oasp.gastronomy.restaurant.tablemanagement.dataaccess.api.TableEntity;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 import io.oasp.module.jpa.dataaccess.api.MasterDataDao;
 
 import java.util.List;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/dataaccess/impl/dao/TableDaoImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/dataaccess/impl/dao/TableDaoImpl.java
@@ -7,9 +7,9 @@ import io.oasp.gastronomy.restaurant.tablemanagement.common.api.datatype.TableSt
 import io.oasp.gastronomy.restaurant.tablemanagement.dataaccess.api.TableEntity;
 import io.oasp.gastronomy.restaurant.tablemanagement.dataaccess.api.dao.TableDao;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.OrderByTo;
-import io.oasp.module.jpa.common.api.to.OrderDirection;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.OrderByTo;
+import io.oasp.module.basic.common.api.to.OrderDirection;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.List;
 

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/api/Tablemanagement.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/api/Tablemanagement.java
@@ -2,7 +2,7 @@ package io.oasp.gastronomy.restaurant.tablemanagement.logic.api;
 
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableEto;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.List;
 

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/api/to/TableSearchCriteriaTo.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/api/to/TableSearchCriteriaTo.java
@@ -1,7 +1,7 @@
 package io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to;
 
 import io.oasp.gastronomy.restaurant.tablemanagement.common.api.datatype.TableState;
-import io.oasp.module.jpa.common.api.to.SearchCriteriaTo;
+import io.oasp.module.basic.common.api.to.SearchCriteriaTo;
 
 /**
  * This is the {@link SearchCriteriaTo search criteria} {@link net.sf.mmm.util.transferobject.api.TransferObject TO}

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/logic/impl/TablemanagementImpl.java
@@ -14,7 +14,7 @@ import io.oasp.gastronomy.restaurant.tablemanagement.dataaccess.api.dao.TableDao
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.Tablemanagement;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableEto;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 import java.util.List;
 import java.util.Objects;

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/service/api/rest/TablemanagementRestService.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/service/api/rest/TablemanagementRestService.java
@@ -16,7 +16,7 @@ import io.oasp.gastronomy.restaurant.general.common.api.RestService;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.Tablemanagement;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableEto;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableSearchCriteriaTo;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 /**
  * The service class for REST calls in order to execute the methods in {@link Tablemanagement}.

--- a/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceImpl.java
+++ b/samples/core/src/main/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceImpl.java
@@ -12,7 +12,7 @@ import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.Tablemanagement;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableEto;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.tablemanagement.service.api.rest.TablemanagementRestService;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 
 /**
  */

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/OfferManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/OfferManagementTest.java
@@ -21,7 +21,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.Offermanagement;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferFilter;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.OfferSortBy;
-import io.oasp.module.jpa.common.api.to.OrderDirection;
+import io.oasp.module.basic.common.api.to.OrderDirection;
 import io.oasp.module.test.common.base.ComponentTest;
 
 /**

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/offermanagement/batch/impl/productimport/ProductManagementTest.java
@@ -21,7 +21,7 @@ import io.oasp.gastronomy.restaurant.offermanagement.logic.api.Offermanagement;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductEto;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductFilter;
 import io.oasp.gastronomy.restaurant.offermanagement.logic.api.to.ProductSortBy;
-import io.oasp.module.jpa.common.api.to.OrderDirection;
+import io.oasp.module.basic.common.api.to.OrderDirection;
 import io.oasp.module.test.common.base.ComponentTest;
 
 /**

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/salesmanagement/service/impl/rest/SalesmanagementRestServiceTest.java
@@ -30,8 +30,8 @@ import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderEto;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderPositionEto;
 import io.oasp.gastronomy.restaurant.salesmanagement.logic.api.to.OrderSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.salesmanagement.service.api.rest.SalesmanagementRestService;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
-import io.oasp.module.jpa.common.api.to.PaginationTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginationTo;
 import io.oasp.module.service.common.api.client.ServiceClientFactory;
 
 /**

--- a/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceTest.java
+++ b/samples/core/src/test/java/io/oasp/gastronomy/restaurant/tablemanagement/service/impl/rest/TablemanagementRestServiceTest.java
@@ -15,7 +15,7 @@ import io.oasp.gastronomy.restaurant.tablemanagement.common.api.datatype.TableSt
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableEto;
 import io.oasp.gastronomy.restaurant.tablemanagement.logic.api.to.TableSearchCriteriaTo;
 import io.oasp.gastronomy.restaurant.tablemanagement.service.api.rest.TablemanagementRestService;
-import io.oasp.module.jpa.common.api.to.PaginatedListTo;
+import io.oasp.module.basic.common.api.to.PaginatedListTo;
 import io.oasp.module.service.common.api.client.ServiceClientFactory;
 import io.oasp.module.service.common.api.client.config.ServiceClientConfigBuilder;
 


### PR DESCRIPTION
As of support for different persistence technologies we observed, that pagination support was wrongly put into the jpa module although it is not jpa specific. This PR resolves this failure by moving the pagination TOs to the basic module.