### PR TITLE
#622: implemented (added AccessControlConfig)

### DIFF
--- a/modules/security/src/main/java/io/oasp/module/security/common/base/accesscontrol/AbstractAccessControlProvider.java
+++ b/modules/security/src/main/java/io/oasp/module/security/common/base/accesscontrol/AbstractAccessControlProvider.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import net.sf.mmm.util.collection.base.NodeCycle;
 import net.sf.mmm.util.collection.base.NodeCycleException;
+import net.sf.mmm.util.exception.api.DuplicateObjectException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -125,6 +126,26 @@ public abstract class AbstractAccessControlProvider implements AccessControlProv
   public AccessControl getAccessControl(String nodeId) {
 
     return this.id2nodeMap.get(nodeId);
+  }
+
+  /**
+   * Registers the given {@link AccessControl} and may be used for configuration of access controls during
+   * bootstrapping. This method should not be used after the application startup (bootstrapping) has completed.
+   *
+   * @param accessControl the {@link AccessControl} to register.
+   */
+  protected void addAccessControl(AccessControl accessControl) {
+
+    String id = accessControl.getId();
+    AccessControl existing = this.id2nodeMap.get(id);
+    if (existing == null) {
+      this.id2nodeMap.put(id, accessControl);
+      LOG.debug("Registered access control {}", accessControl);
+    } else if (existing == accessControl) {
+      LOG.debug("Access control {} was already registered.", accessControl);
+    } else {
+      throw new DuplicateObjectException(accessControl, id, existing);
+    }
   }
 
   @Override

--- a/modules/security/src/main/java/io/oasp/module/security/common/base/accesscontrol/AccessControlConfig.java
+++ b/modules/security/src/main/java/io/oasp/module/security/common/base/accesscontrol/AccessControlConfig.java
@@ -1,0 +1,92 @@
+package io.oasp.module.security.common.base.accesscontrol;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import net.sf.mmm.util.exception.api.DuplicateObjectException;
+
+import io.oasp.module.security.common.api.accesscontrol.AccessControl;
+import io.oasp.module.security.common.api.accesscontrol.AccessControlGroup;
+import io.oasp.module.security.common.api.accesscontrol.AccessControlPermission;
+
+/**
+ * {@link AbstractAccessControlProvider} for static configuration of
+ * {@link io.oasp.module.security.common.api.accesscontrol.AccessControlSchema}. Instead of maintaining it as XML file
+ * you can directly configure it as code and therefore define and reference constants in annotations such as
+ * {@link javax.annotation.security.RolesAllowed}.
+ *
+ * @since 3.0.0
+ */
+public abstract class AccessControlConfig extends AbstractAccessControlProvider {
+
+  /**
+   * Creates a new {@link AccessControlPermission} for static configuration of access controls.
+   *
+   * @param id {@link AccessControlPermission#getId() ID} of {@link AccessControlPermission} to get or create.
+   * @return the existing {@link AccessControlPermission} for the given {@link AccessControlPermission#getId() ID} or a
+   *         newly created and registered {@link AccessControlPermission}.
+   */
+  protected AccessControlPermission permission(String id) {
+
+    AccessControl accessControl = getAccessControl(id);
+    if (accessControl instanceof AccessControlPermission) {
+      return (AccessControlPermission) accessControl;
+    } else if (accessControl != null) {
+      throw new DuplicateObjectException(AccessControlPermission.class.getSimpleName(), id, accessControl);
+    }
+    AccessControlPermission permission = new AccessControlPermission(id);
+    addAccessControl(permission);
+    return permission;
+  }
+
+  /**
+   * Creates a new {@link AccessControlGroup} for static configuration of access controls.
+   *
+   * @param groupId {@link AccessControlGroup#getId() ID} of {@link AccessControlGroup} to create.
+   * @param permissionIds {@link AccessControlPermission#getId() ID}s of the {@link #permission(String) permissions} to
+   *        {@link AccessControlGroup#getPermissions() use}.
+   * @return the newly created and registered {@link AccessControlGroup}.
+   */
+  protected AccessControlGroup group(String groupId, String... permissionIds) {
+
+    return group(groupId, Collections.<AccessControlGroup> emptyList(), permissionIds);
+  }
+
+  /**
+   * Creates a new {@link AccessControlGroup} for static configuration of access controls.
+   *
+   * @param groupId {@link AccessControlGroup#getId() ID} of {@link AccessControlGroup} to create.
+   * @param inherit single {@link AccessControlGroup} to {@link AccessControlGroup#getInherits() inherit}.
+   * @param permissionIds {@link AccessControlPermission#getId() ID}s of the {@link #permission(String) permissions} to
+   *        {@link AccessControlGroup#getPermissions() use}.
+   * @return the newly created and registered {@link AccessControlGroup}.
+   */
+  protected AccessControlGroup group(String groupId, AccessControlGroup inherit, String... permissionIds) {
+
+    return group(groupId, Collections.singletonList(inherit), permissionIds);
+  }
+
+  /**
+   * Creates a new {@link AccessControlGroup} for static configuration of access controls.
+   *
+   * @param groupId {@link AccessControlGroup#getId() ID} of {@link AccessControlGroup} to create.
+   * @param inherits {@link List} of {@link AccessControlGroup} to {@link AccessControlGroup#getInherits() inherit}.
+   * @param permissionIds {@link AccessControlPermission#getId() ID}s of the {@link #permission(String) permissions} to
+   *        {@link AccessControlGroup#getPermissions() use}.
+   * @return the newly created and registered {@link AccessControlGroup}.
+   */
+  protected AccessControlGroup group(String groupId, List<AccessControlGroup> inherits, String... permissionIds) {
+
+    AccessControlGroup group = new AccessControlGroup(groupId);
+    group.setInherits(inherits);
+    List<AccessControlPermission> permissions = new ArrayList<>(permissionIds.length);
+    for (String permissionId : permissionIds) {
+      permissions.add(permission(permissionId));
+    }
+    group.setPermissions(permissions);
+    addAccessControl(group);
+    return group;
+  }
+
+}

--- a/modules/security/src/test/java/io/oasp/module/security/common/impl/accesscontrol/AccessControlConfigSimple.java
+++ b/modules/security/src/test/java/io/oasp/module/security/common/impl/accesscontrol/AccessControlConfigSimple.java
@@ -1,0 +1,89 @@
+package io.oasp.module.security.common.impl.accesscontrol;
+
+import javax.inject.Named;
+
+import io.oasp.module.security.common.api.accesscontrol.AccessControlGroup;
+import io.oasp.module.security.common.base.accesscontrol.AccessControlConfig;
+
+/**
+ * Example of {@link AccessControlConfig} that used for testing.
+ */
+@Named
+public class AccessControlConfigSimple extends AccessControlConfig {
+
+  public static final String APP_ID = "MyApp";
+
+  private static final String PREFIX = APP_ID + ".";
+
+  public static final String PERMISSION_FIND_OFFER = PREFIX + "FindOffer";
+
+  public static final String PERMISSION_SAVE_OFFER = PREFIX + "SaveOffer";
+
+  public static final String PERMISSION_DELETE_OFFER = PREFIX + "DeleteOffer";
+
+  public static final String PERMISSION_FIND_PRODUCT = PREFIX + "FindProduct";
+
+  public static final String PERMISSION_SAVE_PRODUCT = PREFIX + "SaveProduct";
+
+  public static final String PERMISSION_DELETE_PRODUCT = PREFIX + "DeleteProduct";
+
+  public static final String PERMISSION_FIND_TABLE = PREFIX + "FindTable";
+
+  public static final String PERMISSION_SAVE_TABLE = PREFIX + "SaveTable";
+
+  public static final String PERMISSION_DELETE_TABLE = PREFIX + "DeleteTable";
+
+  public static final String PERMISSION_FIND_STAFF_MEMBER = PREFIX + "FindStaffMember";
+
+  public static final String PERMISSION_SAVE_STAFF_MEMBER = PREFIX + "SaveStaffMember";
+
+  public static final String PERMISSION_DELETE_STAFF_MEMBER = PREFIX + "DeleteStaffMember";
+
+  public static final String PERMISSION_FIND_ORDER = PREFIX + "FindOrder";
+
+  public static final String PERMISSION_SAVE_ORDER = PREFIX + "SaveOrder";
+
+  public static final String PERMISSION_DELETE_ORDER = PREFIX + "DeleteOrder";
+
+  public static final String PERMISSION_FIND_ORDER_POSITION = PREFIX + "FindOrderPosition";
+
+  public static final String PERMISSION_SAVE_ORDER_POSITION = PREFIX + "SaveOrderPosition";
+
+  public static final String PERMISSION_DELETE_ORDER_POSITION = PREFIX + "DeleteOrderPosition";
+
+  public static final String PERMISSION_FIND_BILL = PREFIX + "FindBill";
+
+  public static final String PERMISSION_SAVE_BILL = PREFIX + "SaveBill";
+
+  public static final String PERMISSION_DELETE_BILL = PREFIX + "DeleteBill";
+
+  public static final String GROUP_READ_MASTER_DATA = PREFIX + "ReadMasterData";
+
+  public static final String GROUP_COOK = PREFIX + "Cook";
+
+  public static final String GROUP_BARKEEPER = PREFIX + "Barkeeper";
+
+  public static final String GROUP_WAITER = PREFIX + "Waiter";
+
+  public static final String GROUP_CHIEF = PREFIX + "Chief";
+
+  /**
+   * The constructor.
+   */
+  public AccessControlConfigSimple() {
+
+    super();
+    AccessControlGroup readMasterData = group(GROUP_READ_MASTER_DATA, PERMISSION_FIND_OFFER, PERMISSION_FIND_PRODUCT,
+        PERMISSION_FIND_STAFF_MEMBER, PERMISSION_FIND_TABLE);
+    AccessControlGroup cook = group(GROUP_COOK, readMasterData, PERMISSION_FIND_ORDER, PERMISSION_SAVE_ORDER,
+        PERMISSION_FIND_ORDER_POSITION, PERMISSION_SAVE_ORDER_POSITION);
+    AccessControlGroup barkeeper = group(GROUP_BARKEEPER, cook, PERMISSION_FIND_BILL, PERMISSION_SAVE_BILL,
+        PERMISSION_DELETE_BILL, PERMISSION_DELETE_ORDER);
+    AccessControlGroup waiter = group(GROUP_WAITER, barkeeper, PERMISSION_SAVE_TABLE);
+    // AccessControlGroup chief =
+    group(GROUP_CHIEF, waiter, PERMISSION_SAVE_OFFER, PERMISSION_SAVE_PRODUCT, PERMISSION_SAVE_STAFF_MEMBER,
+        PERMISSION_DELETE_OFFER, PERMISSION_DELETE_PRODUCT, PERMISSION_DELETE_STAFF_MEMBER,
+        PERMISSION_DELETE_ORDER_POSITION, PERMISSION_DELETE_TABLE);
+  }
+
+}

--- a/modules/security/src/test/java/io/oasp/module/security/common/impl/accesscontrol/AccessControlConfigTest.java
+++ b/modules/security/src/test/java/io/oasp/module/security/common/impl/accesscontrol/AccessControlConfigTest.java
@@ -1,0 +1,117 @@
+package io.oasp.module.security.common.impl.accesscontrol;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.security.RolesAllowed;
+
+import org.junit.Test;
+
+import io.oasp.module.security.common.api.accesscontrol.AccessControl;
+import io.oasp.module.security.common.api.accesscontrol.AccessControlGroup;
+import io.oasp.module.security.common.base.accesscontrol.AccessControlConfig;
+import io.oasp.module.test.common.base.ModuleTest;
+
+/**
+ * Test of {@link AccessControlConfig}.
+ */
+public class AccessControlConfigTest extends ModuleTest {
+
+  @Test
+  // @RolesAllowed only used to ensure that the constant can be referenced here
+  @RolesAllowed(AccessControlConfigSimple.PERMISSION_FIND_TABLE)
+  public void testSimple() {
+
+    // given + when
+    AccessControlConfigSimple config = new AccessControlConfigSimple();
+    AccessControlGroup chief = (AccessControlGroup) config.getAccessControl(AccessControlConfigSimple.GROUP_CHIEF);
+
+    // then
+    assertThat(chief).isNotNull();
+    assertThat(chief.getId()).isEqualTo(AccessControlConfigSimple.GROUP_CHIEF);
+    assertThat(flatten(chief.getPermissions())).containsExactly(AccessControlConfigSimple.PERMISSION_SAVE_OFFER,
+        AccessControlConfigSimple.PERMISSION_SAVE_PRODUCT, AccessControlConfigSimple.PERMISSION_SAVE_STAFF_MEMBER,
+        AccessControlConfigSimple.PERMISSION_DELETE_OFFER, AccessControlConfigSimple.PERMISSION_DELETE_PRODUCT,
+        AccessControlConfigSimple.PERMISSION_DELETE_STAFF_MEMBER,
+        AccessControlConfigSimple.PERMISSION_DELETE_ORDER_POSITION, AccessControlConfigSimple.PERMISSION_DELETE_TABLE);
+    AccessControlGroup waiter = getSingleInherit(chief);
+    assertThat(waiter).isNotNull();
+    assertThat(waiter.getId()).isEqualTo(AccessControlConfigSimple.GROUP_WAITER);
+    assertThat(flatten(waiter.getPermissions())).containsExactly(AccessControlConfigSimple.PERMISSION_SAVE_TABLE);
+    AccessControlGroup barkeeper = getSingleInherit(waiter);
+    assertThat(barkeeper).isNotNull();
+    assertThat(barkeeper.getId()).isEqualTo(AccessControlConfigSimple.GROUP_BARKEEPER);
+    assertThat(flatten(barkeeper.getPermissions())).containsExactly(AccessControlConfigSimple.PERMISSION_FIND_BILL,
+        AccessControlConfigSimple.PERMISSION_SAVE_BILL, AccessControlConfigSimple.PERMISSION_DELETE_BILL,
+        AccessControlConfigSimple.PERMISSION_DELETE_ORDER);
+    AccessControlGroup cook = getSingleInherit(barkeeper);
+    assertThat(cook).isNotNull();
+    assertThat(cook.getId()).isEqualTo(AccessControlConfigSimple.GROUP_COOK);
+    assertThat(flatten(cook.getPermissions())).containsExactly(AccessControlConfigSimple.PERMISSION_FIND_ORDER,
+        AccessControlConfigSimple.PERMISSION_SAVE_ORDER, AccessControlConfigSimple.PERMISSION_FIND_ORDER_POSITION,
+        AccessControlConfigSimple.PERMISSION_SAVE_ORDER_POSITION);
+    AccessControlGroup readMasterData = getSingleInherit(cook);
+    assertThat(readMasterData).isNotNull();
+    assertThat(readMasterData.getId()).isEqualTo(AccessControlConfigSimple.GROUP_READ_MASTER_DATA);
+    assertThat(flatten(readMasterData.getPermissions())).containsExactly(
+        AccessControlConfigSimple.PERMISSION_FIND_OFFER, AccessControlConfigSimple.PERMISSION_FIND_PRODUCT,
+        AccessControlConfigSimple.PERMISSION_FIND_STAFF_MEMBER, AccessControlConfigSimple.PERMISSION_FIND_TABLE);
+    assertThat(readMasterData.getInherits()).isEmpty();
+
+    // and when
+    Set<String> permissions = new HashSet<>();
+    config.collectAccessControlIds(AccessControlConfigSimple.GROUP_READ_MASTER_DATA, permissions);
+
+    // then
+    assertThat(permissions).containsExactlyInAnyOrder(AccessControlConfigSimple.GROUP_READ_MASTER_DATA,
+        AccessControlConfigSimple.PERMISSION_FIND_OFFER, AccessControlConfigSimple.PERMISSION_FIND_PRODUCT,
+        AccessControlConfigSimple.PERMISSION_FIND_STAFF_MEMBER, AccessControlConfigSimple.PERMISSION_FIND_TABLE);
+
+    // and when
+    permissions = new HashSet<>();
+    config.collectAccessControlIds(AccessControlConfigSimple.GROUP_CHIEF, permissions);
+
+    // then
+    assertThat(permissions).containsExactlyInAnyOrder(AccessControlConfigSimple.GROUP_READ_MASTER_DATA,
+        AccessControlConfigSimple.PERMISSION_FIND_OFFER, AccessControlConfigSimple.PERMISSION_FIND_PRODUCT,
+        AccessControlConfigSimple.PERMISSION_FIND_STAFF_MEMBER, AccessControlConfigSimple.PERMISSION_FIND_TABLE,
+        //
+        AccessControlConfigSimple.GROUP_COOK, AccessControlConfigSimple.PERMISSION_FIND_ORDER,
+        AccessControlConfigSimple.PERMISSION_SAVE_ORDER, AccessControlConfigSimple.PERMISSION_FIND_ORDER_POSITION,
+        AccessControlConfigSimple.PERMISSION_SAVE_ORDER_POSITION,
+        //
+        AccessControlConfigSimple.GROUP_BARKEEPER, AccessControlConfigSimple.PERMISSION_FIND_BILL,
+        AccessControlConfigSimple.PERMISSION_SAVE_BILL, AccessControlConfigSimple.PERMISSION_DELETE_BILL,
+        AccessControlConfigSimple.PERMISSION_DELETE_ORDER,
+        //
+        AccessControlConfigSimple.GROUP_WAITER, AccessControlConfigSimple.PERMISSION_SAVE_TABLE,
+        //
+        AccessControlConfigSimple.GROUP_CHIEF, AccessControlConfigSimple.PERMISSION_SAVE_OFFER,
+        AccessControlConfigSimple.PERMISSION_SAVE_PRODUCT, AccessControlConfigSimple.PERMISSION_SAVE_STAFF_MEMBER,
+        AccessControlConfigSimple.PERMISSION_DELETE_OFFER, AccessControlConfigSimple.PERMISSION_DELETE_PRODUCT,
+        AccessControlConfigSimple.PERMISSION_DELETE_STAFF_MEMBER,
+        AccessControlConfigSimple.PERMISSION_DELETE_ORDER_POSITION, AccessControlConfigSimple.PERMISSION_DELETE_TABLE);
+  }
+
+  private static AccessControlGroup getSingleInherit(AccessControlGroup group) {
+
+    List<AccessControlGroup> inherits = group.getInherits();
+    assertThat(inherits).hasSize(1);
+    AccessControlGroup inheritedGroup = inherits.get(0);
+    assertThat(inheritedGroup).isNotNull();
+    return inheritedGroup;
+  }
+
+  private static String[] flatten(Collection<? extends AccessControl> accessControlList) {
+
+    String[] ids = new String[accessControlList.size()];
+    int i = 0;
+    for (AccessControl accessControl : accessControlList) {
+      ids[i++] = accessControl.getId();
+    }
+    return ids;
+  }
+
+}

--- a/modules/security/src/test/java/io/oasp/module/security/common/impl/accesscontrol/AccessControlConfigTest.java
+++ b/modules/security/src/test/java/io/oasp/module/security/common/impl/accesscontrol/AccessControlConfigTest.java
@@ -19,48 +19,67 @@ import io.oasp.module.test.common.base.ModuleTest;
  */
 public class AccessControlConfigTest extends ModuleTest {
 
+  /**
+   * Test of {@link AccessControlConfig#getAccessControl(String)} with top-level chief group.
+   */
   @Test
   // @RolesAllowed only used to ensure that the constant can be referenced here
   @RolesAllowed(AccessControlConfigSimple.PERMISSION_FIND_TABLE)
-  public void testSimple() {
+  public void testGetAccessControl() {
 
-    // given + when
+    // given
     AccessControlConfigSimple config = new AccessControlConfigSimple();
-    AccessControlGroup chief = (AccessControlGroup) config.getAccessControl(AccessControlConfigSimple.GROUP_CHIEF);
+    String groupChief = AccessControlConfigSimple.GROUP_CHIEF;
+
+    // when
+    AccessControlGroup chief = (AccessControlGroup) config.getAccessControl(groupChief);
 
     // then
     assertThat(chief).isNotNull();
-    assertThat(chief.getId()).isEqualTo(AccessControlConfigSimple.GROUP_CHIEF);
-    assertThat(flatten(chief.getPermissions())).containsExactly(AccessControlConfigSimple.PERMISSION_SAVE_OFFER,
-        AccessControlConfigSimple.PERMISSION_SAVE_PRODUCT, AccessControlConfigSimple.PERMISSION_SAVE_STAFF_MEMBER,
-        AccessControlConfigSimple.PERMISSION_DELETE_OFFER, AccessControlConfigSimple.PERMISSION_DELETE_PRODUCT,
-        AccessControlConfigSimple.PERMISSION_DELETE_STAFF_MEMBER,
+    assertThat(chief.getId()).isEqualTo(groupChief);
+    assertThat(flatten(chief.getPermissions())).containsExactlyInAnyOrder(
+        AccessControlConfigSimple.PERMISSION_SAVE_OFFER, AccessControlConfigSimple.PERMISSION_SAVE_PRODUCT,
+        AccessControlConfigSimple.PERMISSION_SAVE_STAFF_MEMBER, AccessControlConfigSimple.PERMISSION_DELETE_OFFER,
+        AccessControlConfigSimple.PERMISSION_DELETE_PRODUCT, AccessControlConfigSimple.PERMISSION_DELETE_STAFF_MEMBER,
         AccessControlConfigSimple.PERMISSION_DELETE_ORDER_POSITION, AccessControlConfigSimple.PERMISSION_DELETE_TABLE);
     AccessControlGroup waiter = getSingleInherit(chief);
     assertThat(waiter).isNotNull();
     assertThat(waiter.getId()).isEqualTo(AccessControlConfigSimple.GROUP_WAITER);
-    assertThat(flatten(waiter.getPermissions())).containsExactly(AccessControlConfigSimple.PERMISSION_SAVE_TABLE);
+    assertThat(flatten(waiter.getPermissions()))
+        .containsExactlyInAnyOrder(AccessControlConfigSimple.PERMISSION_SAVE_TABLE);
     AccessControlGroup barkeeper = getSingleInherit(waiter);
     assertThat(barkeeper).isNotNull();
     assertThat(barkeeper.getId()).isEqualTo(AccessControlConfigSimple.GROUP_BARKEEPER);
-    assertThat(flatten(barkeeper.getPermissions())).containsExactly(AccessControlConfigSimple.PERMISSION_FIND_BILL,
-        AccessControlConfigSimple.PERMISSION_SAVE_BILL, AccessControlConfigSimple.PERMISSION_DELETE_BILL,
-        AccessControlConfigSimple.PERMISSION_DELETE_ORDER);
+    assertThat(flatten(barkeeper.getPermissions())).containsExactlyInAnyOrder(
+        AccessControlConfigSimple.PERMISSION_FIND_BILL, AccessControlConfigSimple.PERMISSION_SAVE_BILL,
+        AccessControlConfigSimple.PERMISSION_DELETE_BILL, AccessControlConfigSimple.PERMISSION_DELETE_ORDER);
     AccessControlGroup cook = getSingleInherit(barkeeper);
     assertThat(cook).isNotNull();
     assertThat(cook.getId()).isEqualTo(AccessControlConfigSimple.GROUP_COOK);
-    assertThat(flatten(cook.getPermissions())).containsExactly(AccessControlConfigSimple.PERMISSION_FIND_ORDER,
-        AccessControlConfigSimple.PERMISSION_SAVE_ORDER, AccessControlConfigSimple.PERMISSION_FIND_ORDER_POSITION,
+    assertThat(flatten(cook.getPermissions())).containsExactlyInAnyOrder(
+        AccessControlConfigSimple.PERMISSION_FIND_ORDER, AccessControlConfigSimple.PERMISSION_SAVE_ORDER,
+        AccessControlConfigSimple.PERMISSION_FIND_ORDER_POSITION,
         AccessControlConfigSimple.PERMISSION_SAVE_ORDER_POSITION);
     AccessControlGroup readMasterData = getSingleInherit(cook);
     assertThat(readMasterData).isNotNull();
     assertThat(readMasterData.getId()).isEqualTo(AccessControlConfigSimple.GROUP_READ_MASTER_DATA);
-    assertThat(flatten(readMasterData.getPermissions())).containsExactly(
+    assertThat(flatten(readMasterData.getPermissions())).containsExactlyInAnyOrder(
         AccessControlConfigSimple.PERMISSION_FIND_OFFER, AccessControlConfigSimple.PERMISSION_FIND_PRODUCT,
         AccessControlConfigSimple.PERMISSION_FIND_STAFF_MEMBER, AccessControlConfigSimple.PERMISSION_FIND_TABLE);
     assertThat(readMasterData.getInherits()).isEmpty();
+  }
 
-    // and when
+  /**
+   * Test of {@link AccessControlConfig#collectAccessControlIds(String, Set)} with
+   * {@link AccessControlConfigSimple#GROUP_READ_MASTER_DATA}.
+   */
+  @Test
+  public void testCollectAccessControlIds4ReadMasterData() {
+
+    // given
+    AccessControlConfigSimple config = new AccessControlConfigSimple();
+
+    // when
     Set<String> permissions = new HashSet<>();
     config.collectAccessControlIds(AccessControlConfigSimple.GROUP_READ_MASTER_DATA, permissions);
 
@@ -68,10 +87,22 @@ public class AccessControlConfigTest extends ModuleTest {
     assertThat(permissions).containsExactlyInAnyOrder(AccessControlConfigSimple.GROUP_READ_MASTER_DATA,
         AccessControlConfigSimple.PERMISSION_FIND_OFFER, AccessControlConfigSimple.PERMISSION_FIND_PRODUCT,
         AccessControlConfigSimple.PERMISSION_FIND_STAFF_MEMBER, AccessControlConfigSimple.PERMISSION_FIND_TABLE);
+  }
 
-    // and when
-    permissions = new HashSet<>();
-    config.collectAccessControlIds(AccessControlConfigSimple.GROUP_CHIEF, permissions);
+  /**
+   * Test of {@link AccessControlConfig#collectAccessControlIds(String, Set)} with
+   * {@link AccessControlConfigSimple#GROUP_CHIEF}.
+   */
+  @Test
+  public void testCollectAccessControlIds4Chief() {
+
+    // given
+    AccessControlConfigSimple config = new AccessControlConfigSimple();
+    String groupChief = AccessControlConfigSimple.GROUP_CHIEF;
+
+    // when
+    Set<String> permissions = new HashSet<>();
+    config.collectAccessControlIds(groupChief, permissions);
 
     // then
     assertThat(permissions).containsExactlyInAnyOrder(AccessControlConfigSimple.GROUP_READ_MASTER_DATA,
@@ -88,10 +119,9 @@ public class AccessControlConfigTest extends ModuleTest {
         //
         AccessControlConfigSimple.GROUP_WAITER, AccessControlConfigSimple.PERMISSION_SAVE_TABLE,
         //
-        AccessControlConfigSimple.GROUP_CHIEF, AccessControlConfigSimple.PERMISSION_SAVE_OFFER,
-        AccessControlConfigSimple.PERMISSION_SAVE_PRODUCT, AccessControlConfigSimple.PERMISSION_SAVE_STAFF_MEMBER,
-        AccessControlConfigSimple.PERMISSION_DELETE_OFFER, AccessControlConfigSimple.PERMISSION_DELETE_PRODUCT,
-        AccessControlConfigSimple.PERMISSION_DELETE_STAFF_MEMBER,
+        groupChief, AccessControlConfigSimple.PERMISSION_SAVE_OFFER, AccessControlConfigSimple.PERMISSION_SAVE_PRODUCT,
+        AccessControlConfigSimple.PERMISSION_SAVE_STAFF_MEMBER, AccessControlConfigSimple.PERMISSION_DELETE_OFFER,
+        AccessControlConfigSimple.PERMISSION_DELETE_PRODUCT, AccessControlConfigSimple.PERMISSION_DELETE_STAFF_MEMBER,
         AccessControlConfigSimple.PERMISSION_DELETE_ORDER_POSITION, AccessControlConfigSimple.PERMISSION_DELETE_TABLE);
   }
 


### PR DESCRIPTION
This PR implements #622:
* Provides a new class `AccessControlConfig` that implements `AccessControlProvider`. It can therefore be used as a drop-in replacement for `access-control-schema.xml` and `AccessControlProviderImpl`.
* Includes an example config and a JUnit test that verifies that all is working as expected.

Feedback to improve the config "API" is most welcome.
I did not (yet) deprecate the code that may not be used anymore such as `AccessControlProviderImpl` and  `AccessControlSchema`, etc. 
First I want to await feedback from others but I am quite convinced that the old XML stuff is kind of odd compared to the new approach. We still have issues with referencing and code-generation from the XML. All solved as a single source of truth with the new approach where everything is in one place.