### PR TITLE
Fix for issue with Java 1.8 and QueryDSL #599

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>cglib</groupId>
         <artifactId>cglib</artifactId>
-        <version>3.1</version>
+        <version>3.2.4</version>
       </dependency>
       <!-- Support for dynamic and type-safe JPA queries -->
       <dependency>


### PR DESCRIPTION
We are getting this issue as Java 1.8 was not compatible with asm 4.2 dependency that has been used in application. I have tested it by updating the cglib from 3.1 to 3.2.4, as asm dependency is transitive to cglib, it had download asm 5.1 dependency and this had solved the problem

The change required here will be to update the cglib version from 3.1 to 3.2.4 in the bom (oasp4j/bom/pom.xml).

After discussing it with @AbhayChandel  and @sjimenez77 creating a pull request for the same