### PR TITLE
Fix for issue with Java 1.8 and QueryDSL #599

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>cglib</groupId>
         <artifactId>cglib</artifactId>
-        <version>3.1</version>
+        <version>3.2.4</version>
       </dependency>
       <!-- Support for dynamic and type-safe JPA queries -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.7</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <oasp4j.version>2.6.0-SNAPSHOT</oasp4j.version>
+    <oasp4j.version>3.0.0-SNAPSHOT</oasp4j.version>
     <port.range>81</port.range>
     <oasp.flatten.mode>oss</oasp.flatten.mode>
     <spring.boot.version>1.5.3.RELEASE</spring.boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.7</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <oasp4j.version>3.0.0-SNAPSHOT</oasp4j.version>
+    <oasp4j.version>2.6.0-SNAPSHOT</oasp4j.version>
     <port.range>81</port.range>
     <oasp.flatten.mode>oss</oasp.flatten.mode>
     <spring.boot.version>1.5.3.RELEASE</spring.boot.version>


### PR DESCRIPTION
We are getting this issue as Java 1.8 was not compatible with asm 4.2 dependency that has been used in application. I have tested it by updating the cglib from 3.1 to 3.2.4, as asm dependency is transitive to cglib, it had download asm 5.1 dependency and this had solved the problem

The change required here will be to update the cglib version from 3.1 to 3.2.4 in the bom (oasp4j/bom/pom.xml).

After discussing it with @AbhayChandel and @sjimenez77 creating a pull request for the same

