### PR TITLE
#670: minimize dependencies

### DIFF
--- a/modules/security/pom.xml
+++ b/modules/security/pom.xml
@@ -53,12 +53,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
-    <!-- Utilitiy -->
-    <dependency>
-      <groupId>net.sf.m-m-m</groupId>
-      <artifactId>mmm-util-core</artifactId>
-    </dependency>
-
     <!-- Test Dependencies -->
     <dependency>
       <groupId>io.oasp.java.modules</groupId>

--- a/modules/security/src/main/java/io/oasp/module/security/common/base/accesscontrol/AccessControlConfig.java
+++ b/modules/security/src/main/java/io/oasp/module/security/common/base/accesscontrol/AccessControlConfig.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import net.sf.mmm.util.exception.api.DuplicateObjectException;
-
 import io.oasp.module.security.common.api.accesscontrol.AccessControl;
 import io.oasp.module.security.common.api.accesscontrol.AccessControlGroup;
 import io.oasp.module.security.common.api.accesscontrol.AccessControlPermission;
@@ -33,7 +31,7 @@ public abstract class AccessControlConfig extends AbstractAccessControlProvider 
     if (accessControl instanceof AccessControlPermission) {
       return (AccessControlPermission) accessControl;
     } else if (accessControl != null) {
-      throw new DuplicateObjectException(AccessControlPermission.class.getSimpleName(), id, accessControl);
+      throw new IllegalStateException("Duplicate access control for ID '" + id + "'.");
     }
     AccessControlPermission permission = new AccessControlPermission(id);
     addAccessControl(permission);

--- a/modules/security/src/test/java/io/oasp/module/security/common/impl/accesscontrol/AccessControlSchemaTest.java
+++ b/modules/security/src/test/java/io/oasp/module/security/common/impl/accesscontrol/AccessControlSchemaTest.java
@@ -10,8 +10,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import net.sf.mmm.util.collection.base.NodeCycleException;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
@@ -109,8 +107,8 @@ public class AccessControlSchemaTest extends ModuleTest {
     try {
       createProvider(SCHEMA_XML_CYCLIC);
       fail("Exception expected!");
-    } catch (NodeCycleException e) {
-      assertThat(e).hasMessageContaining("[Cook-->Chief-->Barkeeper]");
+    } catch (Exception e) {
+      assertThat(e).hasMessageContaining("Cook-->Chief-->Barkeeper");
     }
   }
 


### PR DESCRIPTION
Some projects want to use devon but only in a pick&choose form with minimum dependencies. In `oasp4j-security` a dependency to `mmm-util-core` was used only to reuse some simple exceptions. That is nice in general and gives exceptions with I18N as we propose but for some reasons in some projects we have to "fight" for each dependency and therefore minimizing makes our life simpler.
After merging this PR the security module should be functionally same except for using simpler standard JDK runtime exceptions in some sepcific error cases (for usage that is deprecated anyhow).