### PR TITLE
Adding Pageable deserializer OOTB

### DIFF
--- a/templates/server/src/main/resources/archetype-resources/core/src/main/java/__packageInPathFormat__/general/common/api/to/PageableJsonDeserializer.java
+++ b/templates/server/src/main/resources/archetype-resources/core/src/main/java/__packageInPathFormat__/general/common/api/to/PageableJsonDeserializer.java
@@ -1,0 +1,61 @@
+package ${package}.general.common.api.to;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.Sort.Order;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.oasp.module.json.common.base.AbstractJsonDeserializer;
+
+/**
+ * This class extends {@link AbstractJsonDeserializer} to deserialize {@link Pageable} objects from JSON
+ *
+ */
+public class PageableJsonDeserializer extends AbstractJsonDeserializer<Pageable> {
+
+  /**
+   * Tries to deserialize a {@link Pageable} object from JSON and creates a new {@link PageRequest}.
+   */
+  @Override
+  protected Pageable deserializeNode(JsonNode node) {
+
+    Sort sort = null;
+
+    int pageNumber = node.get("pageNumber").asInt();
+    int pageSize = node.get("pageSize").asInt();
+
+    if (isSortValid(node)) {
+      JsonNode sortNode = node.get("sort");
+      Iterator<JsonNode> iterator = sortNode.iterator();
+      List<Order> sortingOrders = new ArrayList<>();
+      while (iterator.hasNext()) {
+        JsonNode next = iterator.next();
+        String property = getRequiredValue(next, "property", String.class);
+        String direction = getRequiredValue(next, "direction", String.class);
+        sortingOrders.add(new Order(Direction.valueOf(direction), property));
+      }
+      sort = Sort.by(sortingOrders);
+    }
+
+    return PageRequest.of(pageNumber, pageSize, sort);
+  }
+
+  /**
+   * Checks whether the sort node is present (client may set a {@link Pageable} without a defined sort), is not null
+   * (client may set a null sort) and it is an array
+   *
+   * @param node sort JsonNode to check whether it is valid
+   * @return true if JsonNode is a valid sort
+   */
+  private boolean isSortValid(JsonNode node) {
+
+    return node.get("sort") != null && !node.get("sort").isNull() && node.get("sort").isArray();
+  }
+}

--- a/templates/server/src/main/resources/archetype-resources/core/src/main/java/__packageInPathFormat__/general/common/impl/config/ApplicationObjectMapperFactory.java
+++ b/templates/server/src/main/resources/archetype-resources/core/src/main/java/__packageInPathFormat__/general/common/impl/config/ApplicationObjectMapperFactory.java
@@ -2,7 +2,11 @@ package ${package}.general.common.impl.config;
 
 import javax.inject.Named;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.web.csrf.CsrfToken;
+
+import com.devonfw.poc.angular.general.common.api.to.PageableJsonDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import io.oasp.module.json.common.base.ObjectMapperFactory;
 
@@ -20,5 +24,8 @@ public class ApplicationObjectMapperFactory extends ObjectMapperFactory {
     super();
     // register polymorphic mapping here - see https://github.com/oasp-forge/oasp4j-wiki/wiki/guide-json#json-and-inheritance
     getExtensionModule().addAbstractTypeMapping(CsrfToken.class, CsrfTokenImpl.class);
+	// register Pageable deserializer
+    SimpleModule module = getExtensionModule();
+    module.addDeserializer(Pageable.class, new PageableJsonDeserializer());
   }
 }

--- a/templates/server/src/main/resources/archetype-resources/core/src/main/java/__packageInPathFormat__/general/common/impl/config/ApplicationObjectMapperFactory.java
+++ b/templates/server/src/main/resources/archetype-resources/core/src/main/java/__packageInPathFormat__/general/common/impl/config/ApplicationObjectMapperFactory.java
@@ -5,7 +5,7 @@ import javax.inject.Named;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.web.csrf.CsrfToken;
 
-import com.devonfw.poc.angular.general.common.api.to.PageableJsonDeserializer;
+import ${package}.general.common.api.to.PageableJsonDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import io.oasp.module.json.common.base.ObjectMapperFactory;


### PR DESCRIPTION
This pull requests implements a new `PageableJsonDeserializer` used to deserialize [Pageable ](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/Pageable.html) objects from a JSON file. It extracts the page size, page number, and sort attributes.

Related to [#15 issue](https://github.com/devonfw/devon4j/issues/15) on devon4j. If this pull request gets approved, I will create the same PR there.