### PR TITLE
#689 Fixing h2 console with Spring security

### DIFF
--- a/templates/server/src/main/resources/archetype-resources/core/src/main/java/__packageInPathFormat__/general/service/impl/config/BaseWebSecurityConfig.java
+++ b/templates/server/src/main/resources/archetype-resources/core/src/main/java/__packageInPathFormat__/general/service/impl/config/BaseWebSecurityConfig.java
@@ -88,6 +88,10 @@ public abstract class BaseWebSecurityConfig extends WebSecurityConfigurerAdapter
         // register login and logout filter that handles rest logins
         .addFilterAfter(getSimpleRestAuthenticationFilter(), BasicAuthenticationFilter.class)
         .addFilterAfter(getSimpleRestLogoutFilter(), LogoutFilter.class);
+		
+    // uncomment these lines to enable h2 console
+    // http.csrf().disable();
+    // http.headers().frameOptions().disable();	
 
     if (this.corsEnabled) {
       http.addFilterBefore(getCorsFilter(), CsrfFilter.class);


### PR DESCRIPTION
This pull requests addresses #689.

When enabling spring-security, the H2 database console will be blocked with 403 error, making it impossible to use it. This Pull Request provides a way to fix this issue.

Unfortunately, the drawback is that for using the H2 console you need to disable `csrf` authentication. That is why I decided to comment those lines, so that the user decides when to enable the console.